### PR TITLE
Resample aggregated generation in case of older data with a different resolution

### DIFF
--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -118,8 +118,6 @@ def import_day_ahead_generation(
     scheduled_generation = resample_if_needed(
         scheduled_generation,
         sensors["Scheduled generation"],
-        from_time,
-        until_time,
     )
 
     log.info("Getting green generation ...")

--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -114,11 +114,11 @@ def import_day_ahead_generation(
     abort_if_data_empty(scheduled_generation)
     log.debug("Overall aggregated generation: \n%s" % scheduled_generation)
 
-    log.debug("Up-sampling overall aggregated generation ...")
     if pd.infer_freq(scheduled_generation.index) != "15T":
+        log.debug("Up-sampling overall aggregated generation ...")
         index = pd.date_range(from_time, until_time, freq="15T", closed="left")
         scheduled_generation = scheduled_generation.reindex(index).pad()
-    log.debug("Resampled overall aggregated generation: \n%s" % scheduled_generation)
+        log.debug("Resampled overall aggregated generation: \n%s" % scheduled_generation)
 
     log.info("Getting green generation ...")
     green_generation_df: pd.DataFrame = client.query_wind_and_solar_forecast(

--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -125,21 +125,21 @@ def import_day_ahead_generation(
         country_code, start=from_time, end=until_time, psr_type=None
     )
     abort_if_data_empty(green_generation_df)
-    log.info("Green generation: \n%s" % green_generation_df)
+    log.debug("Green generation: \n%s" % green_generation_df)
 
     log.info("Aggregating green energy columns ...")
     all_green_generation = green_generation_df.sum(axis="columns")
-    log.info("Aggregated green generation: \n%s" % all_green_generation)
+    log.debug("Aggregated green generation: \n%s" % all_green_generation)
 
     log.info("Computing combined generation forecast ...")
     all_generation = scheduled_generation + all_green_generation
-    log.info("Combined generation: \n%s" % all_generation)
+    log.debug("Combined generation: \n%s" % all_generation)
 
     log.info("Computing CO₂ content from the MWh values ...")
     co2_in_kg = calculate_CO2_content_in_kg(scheduled_generation, green_generation_df)
-    log.info("Overall CO₂ content (kg): \n%s" % co2_in_kg)
+    log.debug("Overall CO₂ content (kg): \n%s" % co2_in_kg)
     forecasted_kg_CO2_per_MWh = co2_in_kg / all_generation
-    log.info("Overall CO₂ content (kg/MWh): \n%s" % forecasted_kg_CO2_per_MWh)
+    log.debug("Overall CO₂ content (kg/MWh): \n%s" % forecasted_kg_CO2_per_MWh)
 
     def get_series_for_sensor(sensor):
         if sensor.name == "Scheduled generation":
@@ -175,9 +175,9 @@ def calculate_CO2_content_in_kg(
         + (grey_energy_mix["gas"] * kg_CO2_per_MWh["gas"])
         + (grey_energy_mix["oil"] * kg_CO2_per_MWh["oil"])
     )
-    current_app.logger.info(f"Grey intensity factor: {grey_CO2_intensity_factor}")
+    current_app.logger.debug(f"Grey intensity factor: {grey_CO2_intensity_factor}")
     grey_CO2_content = grey_generation * grey_CO2_intensity_factor
-    current_app.logger.info("Grey CO₂ content (tonnes): \n%s" % grey_CO2_content)
+    current_app.logger.debug("Grey CO₂ content (tonnes): \n%s" % grey_CO2_content)
 
     green_generation["solar CO₂"] = (
         green_generation["Solar"] * kg_CO2_per_MWh["solar"] / 1000.0
@@ -189,7 +189,7 @@ def calculate_CO2_content_in_kg(
         green_generation["Wind Offshore"] * kg_CO2_per_MWh["wind_offshore"]
     )
 
-    current_app.logger.info(
+    current_app.logger.debug(
         "Green generation and CO₂ content: \n%s" % green_generation
     )
 

--- a/prices/day_ahead.py
+++ b/prices/day_ahead.py
@@ -78,7 +78,7 @@ def import_day_ahead_prices(
 
     sensors = ensure_sensors(pricing_sensors)
     # For now, we only have one pricing sensor ...
-    pricing_sensor = sensors[0]
+    pricing_sensor = sensors["Day-ahead prices"]
     assert pricing_sensor.name == "Day-ahead prices"
 
     client = EntsoePandasClient(api_key=auth_token)

--- a/utils.py
+++ b/utils.py
@@ -159,7 +159,7 @@ def parse_from_and_to_dates(
     return from_time, until_time
 
 
-def resample_if_needed(s: pd.Series, sensor: Sensor, start: datetime, end: datetime) -> pd.Series:
+def resample_if_needed(s: pd.Series, sensor: Sensor) -> pd.Series:
     inferred_frequency = pd.infer_freq(s.index)
     if inferred_frequency is None:
         raise ValueError("Data has no discernible frequency from which to derive an event resolution.")
@@ -169,7 +169,7 @@ def resample_if_needed(s: pd.Series, sensor: Sensor, start: datetime, end: datet
         return s
     elif inferred_resolution > target_resolution:
         current_app.logger.debug(f"Upsampling data for {sensor.name} ...")
-        index = pd.date_range(start, end, freq=target_resolution, closed="left")
+        index = pd.date_range(s.index[0], s.index[-1] + inferred_resolution, freq=target_resolution, closed="left")
         s = s.reindex(index).pad()
     elif inferred_resolution < target_resolution:
         current_app.logger.debug(f"Downsampling data for {sensor.name} ...")

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,5 @@
-from typing import Tuple, List, Union
-from datetime import datetime, timedelta
+from typing import Dict, Tuple, Union
+from datetime import datetime
 
 from flask import current_app
 import pandas as pd
@@ -68,14 +68,14 @@ def ensure_transmission_zone_asset() -> GenericAsset:
     return transmission_zone
 
 
-def ensure_sensors(sensor_specifications: Tuple[Tuple]) -> List[Sensor]:
+def ensure_sensors(sensor_specifications: Tuple[Tuple]) -> Dict[str, Sensor]:
     """
     Ensure a GenericAsset exists to model the transmission zone for which this plugin gathers
     generation data, then add specified sensors for relevant data we collect.
 
     If new sensors got created, the session has been flushed.
     """
-    sensors = []
+    sensors = {}
     sensors_created: bool = False
     timezone = current_app.config.get(
         "ENTSOE_COUNTRY_TIMEZONE", DEFAULT_COUNTRY_TIMEZONE
@@ -99,7 +99,7 @@ def ensure_sensors(sensor_specifications: Tuple[Tuple]) -> List[Sensor]:
             db.session.add(sensor)
             sensors_created = True
         sensor.data_by_entsoe = data_by_entsoe
-        sensors.append(sensor)
+        sensors[sensor_name] = sensor
     if sensors_created:
         db.session.flush()
     return sensors


### PR DESCRIPTION
This data, as reported by ENTSO-E, switched from hourly to quarterhourly values on January 1st 2022 at 01:00 UTC.

I guess it would be prudent to follow up with a ticket to add such resolution checks on all imported data, and down-sample or up-sample as needed. Also, to log a warning when the resolution of the incoming data is different than that of the sensor, which could prompt the user to update the sensor resolution (I wouldn't be surprised if even more finegrained data becomes available at some point in the future).