### PR TITLE
Refactor import setup

### DIFF
--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -26,6 +26,7 @@ from ..utils import (
     save_entsoe_series,
     ensure_sensors,
     resample_if_needed,
+    start_import_log,
 )
 
 
@@ -82,16 +83,12 @@ def import_day_ahead_generation(
     Possibly best to run this script somewhere around or maybe two or three hours after 13:00,
     when tomorrow's prices are announced.
     """
-    log = current_app.logger
     country_code = current_app.config.get("ENTSOE_COUNTRY_CODE", DEFAULT_COUNTRY_CODE)
     country_timezone = current_app.config.get(
         "ENTSOE_COUNTRY_TIMEZONE", DEFAULT_COUNTRY_TIMEZONE
     )
 
     auth_token = get_auth_token_from_config_and_set_server_url()
-    log.info(
-        f"Will contact ENTSO-E at {entsoe.entsoe.URL}, country code: {country_code}, country timezone: {country_timezone} ..."
-    )
 
     entsoe_data_source = ensure_data_source()
     derived_data_source = ensure_data_source_for_derived_data()
@@ -101,10 +98,9 @@ def import_day_ahead_generation(
     from_time, until_time = parse_from_and_to_dates_default_tomorrow(
         from_date, to_date, country_timezone
     )
-    log.info(
-        f"Importing generation data from ENTSO-E, starting at {from_time}, up until {until_time} ..."
-    )
 
+    # Start import
+    log, now = start_import_log("day-ahead generation", from_time, until_time, country_code, country_timezone)
     client = EntsoePandasClient(api_key=auth_token)
 
     log.info("Getting scheduled generation ...")

--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -160,7 +160,7 @@ def import_day_ahead_generation(
             entsoe_source = (
                 entsoe_data_source if sensor.data_by_entsoe else derived_data_source
             )
-            save_entsoe_series(series, sensor, entsoe_source, country_timezone)
+            save_entsoe_series(series, sensor, entsoe_source, country_timezone, now)
 
 
 def calculate_CO2_content_in_kg(

--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -97,10 +97,10 @@ def import_day_ahead_generation(
     derived_data_source = ensure_data_source_for_derived_data()
     sensors = ensure_sensors(generation_sensors)
 
+    # Parse CLI options (or set defaults)
     from_time, until_time = parse_from_and_to_dates_default_tomorrow(
         from_date, to_date, country_timezone
     )
-
     log.info(
         f"Importing generation data from ENTSO-E, starting at {from_time}, up until {until_time} ..."
     )

--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -22,7 +22,7 @@ from ..utils import (
     ensure_data_source_for_derived_data,
     get_auth_token_from_config_and_set_server_url,
     abort_if_data_empty,
-    parse_from_and_to_dates,
+    parse_from_and_to_dates_default_tomorrow,
     save_entsoe_series,
     ensure_sensors,
     resample_if_needed,
@@ -97,7 +97,7 @@ def import_day_ahead_generation(
     derived_data_source = ensure_data_source_for_derived_data()
     sensors = ensure_sensors(generation_sensors)
 
-    from_time, until_time = parse_from_and_to_dates(
+    from_time, until_time = parse_from_and_to_dates_default_tomorrow(
         from_date, to_date, country_timezone
     )
 

--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -18,6 +18,8 @@ from .. import (
 )  # noqa: E402
 from . import generation_sensors
 from ..utils import (
+    create_entsoe_client,
+    ensure_country_code_and_timezone,
     ensure_data_source,
     ensure_data_source_for_derived_data,
     get_auth_token_from_config_and_set_server_url,
@@ -83,13 +85,7 @@ def import_day_ahead_generation(
     Possibly best to run this script somewhere around or maybe two or three hours after 13:00,
     when tomorrow's prices are announced.
     """
-    country_code = current_app.config.get("ENTSOE_COUNTRY_CODE", DEFAULT_COUNTRY_CODE)
-    country_timezone = current_app.config.get(
-        "ENTSOE_COUNTRY_TIMEZONE", DEFAULT_COUNTRY_TIMEZONE
-    )
-
-    auth_token = get_auth_token_from_config_and_set_server_url()
-
+    country_code, country_timezone = ensure_country_code_and_timezone()
     entsoe_data_source = ensure_data_source()
     derived_data_source = ensure_data_source_for_derived_data()
     sensors = ensure_sensors(generation_sensors)
@@ -100,8 +96,8 @@ def import_day_ahead_generation(
     )
 
     # Start import
+    client = create_entsoe_client()
     log, now = start_import_log("day-ahead generation", from_time, until_time, country_code, country_timezone)
-    client = EntsoePandasClient(api_key=auth_token)
 
     log.info("Getting scheduled generation ...")
     # We assume that the green (solar & wind) generation is not included in this (it is not scheduled)

--- a/prices/day_ahead.py
+++ b/prices/day_ahead.py
@@ -18,7 +18,7 @@ from .. import (
 )  # noqa: E402
 from ..utils import (
     ensure_data_source,
-    parse_from_and_to_dates,
+    parse_from_and_to_dates_default_tomorrow,
     ensure_sensors,
     save_entsoe_series,
     get_auth_token_from_config_and_set_server_url,
@@ -69,7 +69,7 @@ def import_day_ahead_prices(
 
     entsoe_data_source = ensure_data_source()
 
-    from_time, until_time = parse_from_and_to_dates(
+    from_time, until_time = parse_from_and_to_dates_default_tomorrow(
         from_date, to_date, country_timezone
     )
     log.info(

--- a/prices/day_ahead.py
+++ b/prices/day_ahead.py
@@ -23,6 +23,7 @@ from ..utils import (
     save_entsoe_series,
     get_auth_token_from_config_and_set_server_url,
     abort_if_data_empty,
+    start_import_log,
 )
 
 
@@ -56,16 +57,12 @@ def import_day_ahead_prices(
     Possibly best to run this script somewhere around or maybe two or three hours after 13:00,
     when tomorrow's prices are announced.
     """
-    log = current_app.logger
     country_code = current_app.config.get("ENTSOE_COUNTRY_CODE", DEFAULT_COUNTRY_CODE)
     country_timezone = current_app.config.get(
         "ENTSOE_COUNTRY_TIMEZONE", DEFAULT_COUNTRY_TIMEZONE
     )
 
     auth_token = get_auth_token_from_config_and_set_server_url()
-    log.info(
-        f"Will contact ENTSO-E at {entsoe.entsoe.URL}, country code: {country_code}, country timezone: {country_timezone} ..."
-    )
 
     entsoe_data_source = ensure_data_source()
 
@@ -73,9 +70,9 @@ def import_day_ahead_prices(
     from_time, until_time = parse_from_and_to_dates_default_tomorrow(
         from_date, to_date, country_timezone
     )
-    log.info(
-        f"Importing generation data from ENTSO-E, starting at {from_time}, up until {until_time} ..."
-    )
+
+    # Start import
+    log, now = start_import_log("day-ahead price", from_time, until_time, country_code, country_timezone)
 
     sensors = ensure_sensors(pricing_sensors)
     # For now, we only have one pricing sensor ...

--- a/prices/day_ahead.py
+++ b/prices/day_ahead.py
@@ -64,7 +64,11 @@ def import_day_ahead_prices(
 
     auth_token = get_auth_token_from_config_and_set_server_url()
 
+    sensors = ensure_sensors(pricing_sensors)
     entsoe_data_source = ensure_data_source()
+    # For now, we only have one pricing sensor ...
+    pricing_sensor = sensors["Day-ahead prices"]
+    assert pricing_sensor.name == "Day-ahead prices"
 
     # Parse CLI options (or set defaults)
     from_time, until_time = parse_from_and_to_dates_default_tomorrow(
@@ -73,12 +77,6 @@ def import_day_ahead_prices(
 
     # Start import
     log, now = start_import_log("day-ahead price", from_time, until_time, country_code, country_timezone)
-
-    sensors = ensure_sensors(pricing_sensors)
-    # For now, we only have one pricing sensor ...
-    pricing_sensor = sensors["Day-ahead prices"]
-    assert pricing_sensor.name == "Day-ahead prices"
-
     client = EntsoePandasClient(api_key=auth_token)
 
     log.info("Getting prices ...")

--- a/prices/day_ahead.py
+++ b/prices/day_ahead.py
@@ -69,6 +69,7 @@ def import_day_ahead_prices(
 
     entsoe_data_source = ensure_data_source()
 
+    # Parse CLI options (or set defaults)
     from_time, until_time = parse_from_and_to_dates_default_tomorrow(
         from_date, to_date, country_timezone
     )

--- a/prices/day_ahead.py
+++ b/prices/day_ahead.py
@@ -91,4 +91,4 @@ def import_day_ahead_prices(
     if not dryrun:
         log.info(f"Saving {len(prices)} beliefs for Sensor {pricing_sensor.name} ...")
         prices.name = "event_value"  # required by timely_beliefs, TODO: check if that still is the case, see https://github.com/SeitaBV/timely-beliefs/issues/64
-        save_entsoe_series(prices, pricing_sensor, entsoe_data_source, country_timezone)
+        save_entsoe_series(prices, pricing_sensor, entsoe_data_source, country_timezone, now)

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict, Tuple, Union
+from typing import Dict, Optional, Tuple, Union
 from datetime import datetime
 
 from flask import current_app
@@ -134,10 +134,10 @@ def abort_if_data_empty(data: Union[pd.DataFrame, pd.Series]):
 
 
 def parse_from_and_to_dates(
-    from_date: datetime, to_date: datetime, country_timezone: str
+    from_date: Optional[datetime], to_date: Optional[datetime], country_timezone: str
 ) -> Tuple[datetime, datetime]:
     """
-    Parse CLI options (or set defaults)
+    Parse CLI options (or set default to tomorrow)
     Note:  entsoe-py expects time params as pd.Timestamp
     """
     if to_date is None:

--- a/utils.py
+++ b/utils.py
@@ -213,12 +213,13 @@ def resample_if_needed(s: pd.Series, sensor: Sensor) -> pd.Series:
 
 
 def save_entsoe_series(
-    series: pd.Series, sensor: Sensor, entsoe_source: DataSource, country_timezone: str
+    series: pd.Series, sensor: Sensor, entsoe_source: DataSource, country_timezone: str, now: Optional[datetime] = None
 ):
     """
     Save a series gotten from ENTSO-E to a Flexeasures database.
     """
-    now = server_now().astimezone(pytz.timezone(country_timezone))
+    if not now:
+        now = server_now().astimezone(pytz.timezone(country_timezone))
     belief_times = (
         (series.index.floor("D") - pd.Timedelta("6H"))
         .to_frame(name="clipped_belief_times")

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional, Tuple, Union
 from datetime import datetime
+from logging import Logger
 
 from flask import current_app
 from pandas.tseries.frequencies import to_offset
@@ -260,3 +261,18 @@ def date_range_to_time_range(
 ) -> Tuple[pd.Timestamp, pd.Timestamp]:
     """Because to_date is inclusive, we add one calendar day."""
     return from_date, to_date + pd.offsets.DateOffset(days=1)
+
+
+def start_import_log(
+    import_type: str,
+    from_time: pd.Timestamp,
+    until_time: pd.Timestamp,
+    country_code: str,
+    country_timezone: str
+) -> Tuple[Logger, datetime]:
+    log = current_app.logger
+    log.info(
+        f"Importing {import_type} data for {country_code} (timezone {country_timezone}), starting at {from_time}, up until {until_time}, from ENTSO-E at {entsoe.entsoe.URL} ..."
+    )
+    now = server_now().astimezone(pytz.timezone(country_timezone))
+    return log, now

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ from typing import Dict, Optional, Tuple, Union
 from datetime import datetime
 from logging import Logger
 
+from entsoe import EntsoePandasClient
 from flask import current_app
 from pandas.tseries.frequencies import to_offset
 import pandas as pd
@@ -124,6 +125,20 @@ def get_auth_token_from_config_and_set_server_url() -> str:
         click.echo("Setting ENTSOE_AUTH_TOKEN seems empty!")
         raise click.Abort
     return auth_token
+
+
+def ensure_country_code_and_timezone() -> Tuple[str, str]:
+    country_code = current_app.config.get("ENTSOE_COUNTRY_CODE", DEFAULT_COUNTRY_CODE)
+    country_timezone = current_app.config.get(
+        "ENTSOE_COUNTRY_TIMEZONE", DEFAULT_COUNTRY_TIMEZONE
+    )
+    return country_code, country_timezone
+
+
+def create_entsoe_client() -> EntsoePandasClient:
+    auth_token = get_auth_token_from_config_and_set_server_url()
+    client = EntsoePandasClient(api_key=auth_token)
+    return client
 
 
 def abort_if_data_empty(data: Union[pd.DataFrame, pd.Series]):


### PR DESCRIPTION
I've started to prepare adding a new CLI command to import realized generation. This PR mostly refactors the first few lines of the two CLI imports we have already.

I've also added a date parser that defaults to yesterday rather than tomorrow.
Finally, I made changes to synchronize the recording times of values that are imported within execution of an import command (see https://github.com/SeitaBV/flexmeasures-entsoe/commit/b885842e081ab7011d9afb5ba82a244b35637bdf).