### PR TITLE
docs: update name of plugin setting in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use ``--help`` to learn more usage details.
 First of all, this is a FlexMeasures plugin. Consult the FlexMeasures documentation for setup.
 
 1. Add the path to this directory to your FlexMeasures (>v0.4.0) config file,
-using the `FLEXMEASURES_PLUGIN_PATHS` setting.
+using the `FLEXMEASURES_PLUGINS` setting.
 
 2. Add `ENTSOE_AUTH_TOKEN` to your FlexMeasures config (e.g. ~/.flexmeasures.cfg).
 You can generate this token after you made an account at ENTSO-E, read more [here](https://transparency.entsoe.eu/content/static_content/Static%20content/web%20api/Guide.html#_authentication_and_authorisation). 


### PR DESCRIPTION
The old plugin name is deprecated since a long time, will be sunset in FlexMeasures 0.14