### PR TITLE
Remove bad version check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.0  # New version tags can be found here: https://gitlab.com/pycqa/flake8/-/tags
+-   repo: https://github.com/pycqa/flake8
+    rev: 6.0.0  # New version tags can be found here: https://github.com/pycqa/flake8/tags
     hooks:
     - id: flake8
       name: flake8 (code linting)
       language_version: python3.8
 -   repo: https://github.com/psf/black
-    rev: 20.8b1  # New version tags can be found here: https://github.com/psf/black/tags
+    rev: 22.10.0  # New version tags can be found here: https://github.com/psf/black/tags
     hooks:
     - id: black
       name: black (code formatting)

--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@ DEFAULT_COUNTRY_CODE = "NL"
 DEFAULT_COUNTRY_TIMEZONE = "Europe/Amsterdam"  # This is what we receive, even if ENTSO-E documents Europe/Brussels
 DEFAULT_DERIVED_DATA_SOURCE = "FlexMeasures ENTSO-E"
 
-__version__ = "0.6"
+__version__ = "0.7"
 __settings__ = {
     "ENTSOE_AUTH_TOKEN": dict(
         description="You can generate this token after you made an account at ENTSO-E.",

--- a/utils.py
+++ b/utils.py
@@ -10,8 +10,7 @@ import click
 import pytz
 import entsoe
 
-from flexmeasures import version
-from flexmeasures.data.utils import get_data_source
+from flexmeasures.data.utils import get_data_source, save_to_db
 from flexmeasures.data.models.time_series import Sensor
 from flexmeasures.data.models.generic_assets import GenericAsset, GenericAssetType
 from flexmeasures.data.models.data_sources import DataSource
@@ -255,26 +254,13 @@ def save_entsoe_series(
     )
 
     # TODO: evaluate some traits of the data via FlexMeasures, see https://github.com/SeitaBV/flexmeasures-entsoe/issues/3
-    # TODO: deprecate save_to_db (from api.common)
-    if version("flexmeasures") < "0.8":
-        from flexmeasures.api.common.utils.api_utils import (
-            save_to_db as deprecated_save_to_db,
+    status = save_to_db(bdf)
+    if status == "success_but_nothing_new":
+        current_app.logger.info(
+            "Done. These beliefs had already been saved before."
         )
-
-        current_app.logger.warning(
-            "Calling flexmeasures.api.common.utils.api_utils.save_to_db is deprecated. Consider switching to FlexMeasures >= 0.8.0"
-        )
-        deprecated_save_to_db(bdf)
-    else:
-        from flexmeasures.data.utils import save_to_db
-
-        status = save_to_db(bdf)
-        if status == "success_but_nothing_new":
-            current_app.logger.info(
-                "Done. These beliefs had already been saved before."
-            )
-        elif status == "success_with_unchanged_beliefs_skipped":
-            current_app.logger.info("Done. Some beliefs had already been saved before.")
+    elif status == "success_with_unchanged_beliefs_skipped":
+        current_app.logger.info("Done. Some beliefs had already been saved before.")
 
 
 def date_range_to_time_range(

--- a/utils.py
+++ b/utils.py
@@ -54,9 +54,7 @@ def ensure_transmission_zone_asset(country_code: str) -> Asset:
         )
         db.session.add(transmission_zone_type)
     ga_name = f"{country_code} transmission zone"
-    transmission_zone = Asset.query.filter(
-        Asset.name == ga_name
-    ).one_or_none()
+    transmission_zone = Asset.query.filter(Asset.name == ga_name).one_or_none()
     if not transmission_zone:
         current_app.logger.info(f"Adding {ga_name} ...")
         transmission_zone = Asset(
@@ -129,7 +127,9 @@ def ensure_country_code_and_timezone(
     country_timezone: Optional[str] = None,
 ) -> Tuple[str, str]:
     if country_code is None:
-        country_code = current_app.config.get("ENTSOE_COUNTRY_CODE", DEFAULT_COUNTRY_CODE)
+        country_code = current_app.config.get(
+            "ENTSOE_COUNTRY_CODE", DEFAULT_COUNTRY_CODE
+        )
     if country_timezone is None:
         country_timezone = current_app.config.get(
             "ENTSOE_COUNTRY_TIMEZONE", DEFAULT_COUNTRY_TIMEZONE
@@ -230,7 +230,11 @@ def resample_if_needed(s: pd.Series, sensor: Sensor) -> pd.Series:
 
 
 def save_entsoe_series(
-    series: pd.Series, sensor: Sensor, entsoe_source: Source, country_timezone: str, now: Optional[datetime] = None
+    series: pd.Series,
+    sensor: Sensor,
+    entsoe_source: Source,
+    country_timezone: str,
+    now: Optional[datetime] = None,
 ):
     """
     Save a series gotten from ENTSO-E to a FlexMeasures database.
@@ -254,9 +258,7 @@ def save_entsoe_series(
     # TODO: evaluate some traits of the data via FlexMeasures, see https://github.com/SeitaBV/flexmeasures-entsoe/issues/3
     status = save_to_db(bdf)
     if status == "success_but_nothing_new":
-        current_app.logger.info(
-            "Done. These beliefs had already been saved before."
-        )
+        current_app.logger.info("Done. These beliefs had already been saved before.")
     elif status == "success_with_unchanged_beliefs_skipped":
         current_app.logger.info("Done. Some beliefs had already been saved before.")
 
@@ -273,7 +275,7 @@ def start_import_log(
     from_time: pd.Timestamp,
     until_time: pd.Timestamp,
     country_code: str,
-    country_timezone: str
+    country_timezone: str,
 ) -> Tuple[Logger, datetime]:
     log = current_app.logger
     log.info(


### PR DESCRIPTION
The version check wasn't working correctly, so even with FlexMeasures versions >0.8 warnings were being logged and a deprecated util function was being called. In this PR, I chose to assume a more recent FlexMeasures version is used. Toplevel imports of FlexMeasures classes is supported from 0.9 onwards (see [our changelogs](https://flexmeasures.readthedocs.io/en/latest/changelog.html#id36)).

I couldn't set a minimum FlexMeasures version yet, because this is not a real package yet (see https://github.com/SeitaBV/flexmeasures-entsoe/issues/11).