### PR TITLE
Get today's prices by default

### DIFF
--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -24,7 +24,7 @@ from ..utils import (
     ensure_data_source_for_derived_data,
     get_auth_token_from_config_and_set_server_url,
     abort_if_data_empty,
-    parse_from_and_to_dates_default_tomorrow,
+    parse_from_and_to_dates_default_today_and_tomorrow,
     save_entsoe_series,
     ensure_sensors,
     resample_if_needed,
@@ -59,7 +59,7 @@ kg_CO2_per_MWh = dict(
     "--from-date",
     required=False,
     type=click.DateTime(["%Y-%m-%d"]),
-    help="Query data from this date onwards. If not specified, defaults to --to-date",
+    help="Query data from this date onwards. If not specified, defaults to today",
 )
 @click.option(
     "--to-date",
@@ -106,7 +106,7 @@ def import_day_ahead_generation(
     sensors = ensure_sensors(generation_sensors, country_code, country_timezone)
 
     # Parse CLI options (or set defaults)
-    from_time, until_time = parse_from_and_to_dates_default_tomorrow(
+    from_time, until_time = parse_from_and_to_dates_default_today_and_tomorrow(
         from_date, to_date, country_timezone
     )
 

--- a/generation/day_ahead.py
+++ b/generation/day_ahead.py
@@ -94,7 +94,7 @@ def import_day_ahead_generation(
     country_timezone: Optional[str] = None,
 ):
     """
-    Import forecasted generation for any date range, defaulting to tomorrow.
+    Import forecasted generation for any date range, defaulting to today and tomorrow.
     This will save overall generation, solar, offshore and onshore wind, and the estimated CO₂ content per hour.
     Possibly best to run this script somewhere around or maybe two or three hours after 13:00,
     when tomorrow's prices are announced.

--- a/prices/day_ahead.py
+++ b/prices/day_ahead.py
@@ -20,7 +20,7 @@ from ..utils import (
     create_entsoe_client,
     ensure_country_code_and_timezone,
     ensure_data_source,
-    parse_from_and_to_dates_default_tomorrow,
+    parse_from_and_to_dates_default_today_and_tomorrow,
     ensure_sensors,
     save_entsoe_series,
     get_auth_token_from_config_and_set_server_url,
@@ -34,7 +34,7 @@ from ..utils import (
     "--from-date",
     required=False,
     type=click.DateTime(["%Y-%m-%d"]),
-    help="Query data from this date onwards. If not specified, defaults to --to-date",
+    help="Query data from this date onwards. If not specified, defaults to today",
 )
 @click.option(
     "--to-date",
@@ -69,7 +69,7 @@ def import_day_ahead_prices(
     country_timezone: Optional[str] = None,
 ):
     """
-    Import forecasted prices for any date range, defaulting to tomorrow.
+    Import forecasted prices for any date range, defaulting to today and tomorrow.
     Possibly best to run this script somewhere around or maybe two or three hours after 13:00,
     when tomorrow's prices are announced.
     """
@@ -82,7 +82,7 @@ def import_day_ahead_prices(
     assert pricing_sensor.name == "Day-ahead prices"
 
     # Parse CLI options (or set defaults)
-    from_time, until_time = parse_from_and_to_dates_default_tomorrow(
+    from_time, until_time = parse_from_and_to_dates_default_today_and_tomorrow(
         from_date, to_date, country_timezone
     )
 

--- a/utils.py
+++ b/utils.py
@@ -151,11 +151,11 @@ def abort_if_data_empty(data: Union[pd.DataFrame, pd.Series]):
         raise click.Abort
 
 
-def parse_from_and_to_dates_default_tomorrow(
+def parse_from_and_to_dates_default_today_and_tomorrow(
     from_date: Optional[datetime], to_date: Optional[datetime], country_timezone: str
 ) -> Tuple[datetime, datetime]:
     """
-    Parse CLI options (or set default to tomorrow)
+    Parse CLI options (or set default to today and tomorrow)
     Note:  entsoe-py expects time params as pd.Timestamp
     """
     today_start = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)

--- a/utils.py
+++ b/utils.py
@@ -158,10 +158,8 @@ def parse_from_and_to_dates_default_tomorrow(
     Parse CLI options (or set default to tomorrow)
     Note:  entsoe-py expects time params as pd.Timestamp
     """
+    today_start = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
     if to_date is None:
-        today_start = datetime.today().replace(
-            hour=0, minute=0, second=0, microsecond=0
-        )
         to_date = pd.Timestamp(
             today_start, tzinfo=pytz.timezone(country_timezone)
         ) + pd.offsets.DateOffset(
@@ -170,7 +168,7 @@ def parse_from_and_to_dates_default_tomorrow(
     else:
         to_date = pd.Timestamp(to_date, tzinfo=pytz.timezone(country_timezone))
     if from_date is None:
-        from_date = to_date
+        from_date = pd.Timestamp(today_start, tzinfo=pytz.timezone(country_timezone))
     else:
         from_date = pd.Timestamp(from_date, tzinfo=pytz.timezone(country_timezone))
     from_time, until_time = date_range_to_time_range(from_date, to_date)


### PR DESCRIPTION
In this PR, I have updated `from_date` value. Before, if it was not given then it was equal to  `to_date` which means that prices would start from tomorrow. Now I dropped this extra day so we will get today's prices by default if user doesn't provide `--from-date` in the cli arguments.