### PR TITLE
Remove `language_version` from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,11 @@ repos:
     hooks:
     - id: flake8
       name: flake8 (code linting)
-      language_version: python3.8
 -   repo: https://github.com/psf/black
     rev: 22.10.0  # New version tags can be found here: https://github.com/psf/black/tags
     hooks:
     - id: black
       name: black (code formatting)
-      language_version: python3.8
 -   repo: local
     hooks:
     - id: mypy


### PR DESCRIPTION
In this PR, I just dropped the python version dependency, which we already did in other repos.