### PR TITLE
add sensor as a CLI option

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,7 +10,7 @@ DEFAULT_COUNTRY_CODE = "NL"
 DEFAULT_COUNTRY_TIMEZONE = "Europe/Amsterdam"  # This is what we receive, even if ENTSO-E documents Europe/Brussels
 DEFAULT_DERIVED_DATA_SOURCE = "FlexMeasures ENTSO-E"
 
-__version__ = "0.7"
+__version__ = "0.8"
 __settings__ = {
     "ENTSOE_AUTH_TOKEN": dict(
         description="You can generate this token after you made an account at ENTSO-E.",

--- a/prices/day_ahead.py
+++ b/prices/day_ahead.py
@@ -78,7 +78,7 @@ from ..utils import (
     "source",
     type=DataSourceIdField(),
     required=False,
-    help="Timezone for the country (such as 'Europe/Amsterdam').",
+    help="Source of the price data. If not provided, the source `ENTSO-E` is used.",
 )
 @with_appcontext
 @task_with_status_report("entsoe-import-day-ahead-prices")
@@ -112,7 +112,6 @@ def import_day_ahead_prices(
     else:
         pricing_sensor = sensor
 
-    breakpoint()
     # Parse CLI options (or set defaults)
     from_time, until_time = parse_from_and_to_dates_default_today_and_tomorrow(
         from_date, to_date, country_timezone


### PR DESCRIPTION
This PR makes possible passing a sensor id to the the command `import-day-ahead-prices`, for example:

```
flexmeasures entsoe import-day-ahead-prices --sensor 597
```

