### PR TITLE
Feat/prepare for go-live of ENTSO-E moving day-ahead prices from 1 hour to 15 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ flexmeasures edit resample-data --sensor <ID of your day-ahead price sensor> --e
 
 The `flexmeasures-entsoe` package already automatically resamples the ENTSO-E data to the resolution of your sensor.
 
-If you have any price sensors using a Reporter to derive values from the day-ahead wholesale prices, there is no need to update the configuration of each Reporters; just resample the derived price sensors using the previous command (replacing the sensor ID as needed).
+If you use a `Reporter` to derive retail prices or to compute energy costs, there is no need to update its configuration; just resample these sensors too, using the previous command (replacing the sensor ID as needed).
+Alternatively, if you want to keep these sensors in their original resolution, and find that your reporters fail with an `AssertionError` about mismatched resolutions, you may need to add the `--resolution PT1H` option when using the `flexmeasures add report` command.
 
 #### 2. Getting a new sensor
 
@@ -59,12 +60,14 @@ If you have any price sensors using a Reporter to derive values from the day-ahe
 
 The `flexmeasures-entsoe` package will then automatically create a new 15-minute price sensor the next time `flexmeasures entsoe import-day-ahead-prices` is run, assigning it a new sensor ID.
 
-If you have any price sensors using a `Reporter` to derive values from the day-ahead wholesale prices, update the sensor ID in the configuration of each `Reporter`.
-Finally, resample each derived price sensor using:
+If you have any price or costs sensors using a `Reporter` to derive values from the day-ahead wholesale prices, update the sensor ID in the configuration of each `Reporter`.
+Finally, either resample each derived sensor using:
 
 ```bash
-flexmeasures edit resample-data --sensor <ID of your derivative price sensor> --event-resolution 15
+flexmeasures edit resample-data --sensor <ID of your derivative sensor> --event-resolution 15
 ```
+
+or, if you want to keep these sensors in their original resolution, and find that your reporters fail with an `AssertionError` about mismatched resolutions, you may need to add the `--resolution PT1H` option when using the `flexmeasures add report` command.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ If you do this *after* the go-live moment, the `flexmeasures-entsoe` package jus
 
 #### 1. Resampling
 
-**The upside** of resampling your existing price data is that the sensor ID of your price sensor in FlexMeasures will remain the same. Depending on your system setup, Forecaster/Reporter/Scheduler configurations (such as an asset's `flex-context`) may depend on it, and your users may expect the 15-minute data to live under the same sensor.
+**The upside** of resampling your existing price data is that the sensor ID of your price sensor in FlexMeasures will remain the same.
+Depending on your system setup, `Forecaster`/`Reporter`/`Scheduler` configurations (such as an asset's `flex-context`) may depend on it, and your users may expect the 15-minute data to live under the same sensor.
 
 **The downside** is that it quadruples your data for that sensor, due to the fact that FlexMeasures only supports a fixed resolution for any given sensor. Although there should be no noticeable hit in performance, it obviously leads to redundant data in the price history before October 1st 2025.  
 
@@ -52,13 +53,13 @@ If you have any price sensors using a Reporter to derive values from the day-ahe
 
 **The upside** is that this doesn't quadruple your historic data (see *the downside* of resampling, above).
 
-**The downside** is that you may need to revise Forecaster/Reporter/Scheduler configurations (such as an asset's `flex-context`) and notify users (see *the upside* of resampling, above).
+**The downside** is that you may need to revise `Forecaster`/`Reporter`/`Scheduler` configurations (such as an asset's `flex-context`) and notify users (see *the upside* of resampling, above).
 
 **To get a new sensor**, rename your existing *Day-ahead prices* sensor in the FlexMeasures UI.
 
 The `flexmeasures-entsoe` package will then automatically create a new 15-minute price sensor the next time `flexmeasures entsoe import-day-ahead-prices` is run, assigning it a new sensor ID.
 
-If you have any price sensors using a Reporter to derive values from the day-ahead wholesale prices, update the sensor ID in the configuration of each Reporter.
+If you have any price sensors using a `Reporter` to derive values from the day-ahead wholesale prices, update the sensor ID in the configuration of each `Reporter`.
 Finally, resample each derived price sensor using:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@ ENTSO-E is moving from 1-hour day-ahead prices 15-minute day-ahead prices on Oct
 To prepare for this transition, you have two choices:
 
 1. resample your existing price sensor in FlexMeasures from 1 hour to 15 minutes, or
-2. create a new price sensor in FlexMeasures with a 15-min resolution.
+2. get a new sensor for the 15-minute data.
+
+If you do this *after* the go-live moment, the `flexmeasures-entsoe` package just keeps resampling the 15-minute ENTSO-E data to hourly data.
 
 #### 1. Resampling
 
@@ -44,25 +46,15 @@ flexmeasures edit resample-data --sensor <ID of your day-ahead price sensor> --e
 
 The `flexmeasures-entsoe` package already automatically resamples the ENTSO-E data to the resolution of your sensor.
 
-#### 2. Creating a new sensor
+#### 2. Getting a new sensor
 
 **The upside** is that this doesn't quadruple your historic data (see *the downside* of resampling, above).
 
 **The downside** is that you may need to revise Forecaster/Reporter/Scheduler configurations (such as an asset's `flex-context`) and notify users (see *the upside* of resampling, above).
 
-**To create a new sensor**, in this example for the NL bidding zone, use:
+**To get a new sensor**, rename your existing *Day-ahead prices* sensor in the FlexMeasures UI. 
 
-```bash
-flexmeasures add sensor --name '15-min day-ahead prices' --unit EUR/MWh --event-resolution PT15M --timezone Europe/Amsterdam --asset <ID of your 'NL transmission zone' asset>
-```
-
-and pass your new sensor ID when calling the price import command:
-
-```bash
-flexmeasures entsoe import-day-ahead-prices --sensor <new sensor ID> --country NL
-```
-
-The `flexmeasures-entsoe` package already automatically resamples the ENTSO-E data to the resolution of your sensor.
+The `flexmeasures-entsoe` package will then automatically create a new 15-minute price sensor the next time `flexmeasures entsoe import-day-ahead-prices` is run.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Use ``--help`` to learn more usage details.
 
 ### October 1st 2025 go-live for ENTSO-E moving to 15-minute day-ahead prices
 
-You have two choices:
+ENTSO-E is moving from 1-hour day-ahead prices 15-minute day-ahead prices on October 1st 2025.
+To prepare for this transition, you have two choices:
 
 1. resample your existing price sensor in FlexMeasures from 1 hour to 15 minutes, or
 2. create a new price sensor in FlexMeasures with a 15-min resolution.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,47 @@ Importing tomorrow's generation (incl. CO2 estimated content):
 Use ``--help`` to learn more usage details.
 
 
+### October 1st 2025 go-live for ENTSO-E moving to 15-minute day-ahead prices
+
+You have two choices:
+
+1. resample your existing price sensor in FlexMeasures from 1 hour to 15 minutes, or
+2. create a new price sensor in FlexMeasures with a 15-min resolution.
+
+#### 1. Resampling
+
+**The upside** of resampling your existing price data is that the sensor ID of your price sensor in FlexMeasures will remain the same. Depending on your system setup, Forecaster/Reporter/Scheduler configurations (such as an asset's `flex-context`) may depend on it, and your users may expect the 15-minute data to live under the same sensor.
+
+**The downside** is that it quadruples your data for that sensor, due to the fact that FlexMeasures only supports a fixed resolution for any given sensor. Although there should be no noticeable hit in performance, it obviously leads to redundant data in the price history before October 1st 2025.  
+
+**To resample** your historical data, use:
+
+```bash
+flexmeasures edit resample-data --sensor <ID of your day-ahead price sensor> --event-resolution 15
+```
+
+The `flexmeasures-entsoe` package already automatically resamples the ENTSO-E data to the resolution of your sensor.
+
+#### 2. Creating a new sensor
+
+**The upside** is that this doesn't quadruple your historic data (see *the downside* of resampling, above).
+
+**The downside** is that you may need to revise Forecaster/Reporter/Scheduler configurations (such as an asset's `flex-context`) and notify users (see *the upside* of resampling, above).
+
+**To create a new sensor**, in this example for the NL bidding zone, use:
+
+```bash
+flexmeasures add sensor --name '15-min day-ahead prices' --unit EUR/MWh --event-resolution PT15M --timezone Europe/Amsterdam --asset <ID of your 'NL transmission zone' asset>
+```
+
+and pass your new sensor ID when calling the price import command:
+
+```bash
+flexmeasures entsoe import-day-ahead-prices --sensor <new sensor ID> --country NL
+```
+
+The `flexmeasures-entsoe` package already automatically resamples the ENTSO-E data to the resolution of your sensor.
+
 ## Installation
 
 First of all, this is a FlexMeasures plugin. Consult the FlexMeasures documentation for setup.

--- a/README.md
+++ b/README.md
@@ -46,15 +46,24 @@ flexmeasures edit resample-data --sensor <ID of your day-ahead price sensor> --e
 
 The `flexmeasures-entsoe` package already automatically resamples the ENTSO-E data to the resolution of your sensor.
 
+If you have any price sensors using a Reporter to derive values from the day-ahead wholesale prices, there is no need to update the configuration of each Reporters; just resample the derived price sensors using the previous command (replacing the sensor ID as needed).
+
 #### 2. Getting a new sensor
 
 **The upside** is that this doesn't quadruple your historic data (see *the downside* of resampling, above).
 
 **The downside** is that you may need to revise Forecaster/Reporter/Scheduler configurations (such as an asset's `flex-context`) and notify users (see *the upside* of resampling, above).
 
-**To get a new sensor**, rename your existing *Day-ahead prices* sensor in the FlexMeasures UI. 
+**To get a new sensor**, rename your existing *Day-ahead prices* sensor in the FlexMeasures UI.
 
-The `flexmeasures-entsoe` package will then automatically create a new 15-minute price sensor the next time `flexmeasures entsoe import-day-ahead-prices` is run.
+The `flexmeasures-entsoe` package will then automatically create a new 15-minute price sensor the next time `flexmeasures entsoe import-day-ahead-prices` is run, assigning it a new sensor ID.
+
+If you have any price sensors using a Reporter to derive values from the day-ahead wholesale prices, update the sensor ID in the configuration of each Reporter.
+Finally, resample each derived price sensor using:
+
+```bash
+flexmeasures edit resample-data --sensor <ID of your derivative price sensor> --event-resolution 15
+```
 
 ## Installation
 

--- a/flexmeasures_entsoe/__init__.py
+++ b/flexmeasures_entsoe/__init__.py
@@ -10,7 +10,7 @@ DEFAULT_COUNTRY_CODE = "NL"
 DEFAULT_COUNTRY_TIMEZONE = "Europe/Amsterdam"  # This is what we receive, even if ENTSO-E documents Europe/Brussels
 DEFAULT_DERIVED_DATA_SOURCE = "FlexMeasures ENTSO-E"
 
-__version__ = "0.8"
+__version__ = "0.9"
 __settings__ = {
     "ENTSOE_AUTH_TOKEN": dict(
         description="You can generate this token after you made an account at ENTSO-E.",

--- a/flexmeasures_entsoe/generation/day_ahead.py
+++ b/flexmeasures_entsoe/generation/day_ahead.py
@@ -165,7 +165,6 @@ def import_day_ahead_generation(
         for sensor in sensors.values():
             series = get_series_for_sensor(sensor)
             log.info(f"Saving {len(series)} beliefs for Sensor {sensor.name} ...")
-            series.name = "event_value"  # required by timely_beliefs, TODO: check if that still is the case, see https://github.com/SeitaBV/timely-beliefs/issues/64
             entsoe_source = (
                 entsoe_data_source if sensor.data_by_entsoe else derived_data_source
             )

--- a/flexmeasures_entsoe/prices/__init__.py
+++ b/flexmeasures_entsoe/prices/__init__.py
@@ -1,4 +1,4 @@
 from datetime import timedelta
 
 # sensor_name, unit, even_resolution, data sourced directly by ENTSO-E or not (i.e. derived)
-pricing_sensors = (("Day-ahead prices", "EUR/MWh", timedelta(hours=1), True),)
+pricing_sensors = (("Day-ahead prices", "EUR/MWh", timedelta(minutes=15), True),)

--- a/flexmeasures_entsoe/prices/day_ahead.py
+++ b/flexmeasures_entsoe/prices/day_ahead.py
@@ -124,6 +124,10 @@ def import_day_ahead_prices(
         country_code, start=from_time, end=until_time
     )
     abort_if_data_empty(prices)
+
+    if pricing_sensor.event_resolution != pd.Timedelta(hours=1):
+        prices = prices.reindex(prices.index.append(pd.DatetimeIndex([prices.index[-1] + prices.index.freq]))).resample("15min").ffill().head(-1)
+
     log.debug("Prices: \n%s" % prices)
 
     if not dryrun:

--- a/flexmeasures_entsoe/prices/day_ahead.py
+++ b/flexmeasures_entsoe/prices/day_ahead.py
@@ -130,7 +130,6 @@ def import_day_ahead_prices(
 
     if not dryrun:
         log.info(f"Saving {len(prices)} beliefs for Sensor {pricing_sensor.name} ...")
-        prices.name = "event_value"  # required by timely_beliefs, TODO: check if that still is the case, see https://github.com/SeitaBV/timely-beliefs/issues/64
         save_entsoe_series(
             prices, pricing_sensor, entsoe_data_source, country_timezone, now
         )

--- a/flexmeasures_entsoe/prices/day_ahead.py
+++ b/flexmeasures_entsoe/prices/day_ahead.py
@@ -26,6 +26,7 @@ from ..utils import (
     ensure_sensors,
     save_entsoe_series,
     abort_if_data_empty,
+    resample_if_needed,
     start_import_log,
 )
 
@@ -124,10 +125,7 @@ def import_day_ahead_prices(
         country_code, start=from_time, end=until_time
     )
     abort_if_data_empty(prices)
-
-    if pricing_sensor.event_resolution != pd.Timedelta(hours=1):
-        prices = prices.reindex(prices.index.append(pd.DatetimeIndex([prices.index[-1] + prices.index.freq]))).resample("15min").ffill().head(-1)
-
+    prices = resample_if_needed(prices, pricing_sensor)
     log.debug("Prices: \n%s" % prices)
 
     if not dryrun:

--- a/flexmeasures_entsoe/prices/day_ahead.py
+++ b/flexmeasures_entsoe/prices/day_ahead.py
@@ -8,9 +8,7 @@ from flexmeasures import Source, Sensor
 
 from flexmeasures.data.transactional import task_with_status_report
 
-from flexmeasures.data.schemas import (
-    SensorIdField
-)
+from flexmeasures.data.schemas import SensorIdField
 from flexmeasures.data.schemas.sources import DataSourceIdField
 
 
@@ -83,8 +81,8 @@ def import_day_ahead_prices(
     to_date: Optional[datetime] = None,
     country_code: Optional[str] = None,
     country_timezone: Optional[str] = None,
-    sensor : Optional[Sensor] = None,
-    source : Optional[Source] = None
+    sensor: Optional[Sensor] = None,
+    source: Optional[Source] = None,
 ):
     """
     Import forecasted prices for any date range, defaulting to today and tomorrow.
@@ -95,7 +93,7 @@ def import_day_ahead_prices(
     country_code, country_timezone = ensure_country_code_and_timezone(
         country_code, country_timezone
     )
-    
+
     if source is None:
         entsoe_data_source = ensure_data_source()
     else:

--- a/flexmeasures_entsoe/utils.py
+++ b/flexmeasures_entsoe/utils.py
@@ -98,6 +98,8 @@ def ensure_sensors(
             )
             db.session.add(sensor)
             sensors_created = True
+        elif sensor.event_resolution != event_resolution:
+            current_app.logger.warning(f"The {sensor_name} sensor exists, but has a resolution of {sensor.event_resolution} instead of {event_resolution}. Please refer the 'October 1st 2025 go-live' instructions in `README.md`.")
         sensor.data_by_entsoe = data_by_entsoe
         sensors[sensor_name] = sensor
     if sensors_created:

--- a/flexmeasures_entsoe/utils.py
+++ b/flexmeasures_entsoe/utils.py
@@ -219,7 +219,7 @@ def resample_if_needed(s: pd.Series, sensor: Sensor) -> pd.Series:
             s.index[0],
             s.index[-1] + inferred_resolution,
             freq=target_resolution,
-            closed="left",
+            inclusive="left",
         )
         s = s.reindex(index).pad()
     elif inferred_resolution < target_resolution:

--- a/flexmeasures_entsoe/utils.py
+++ b/flexmeasures_entsoe/utils.py
@@ -99,7 +99,9 @@ def ensure_sensors(
             db.session.add(sensor)
             sensors_created = True
         elif sensor.event_resolution != event_resolution:
-            current_app.logger.warning(f"The {sensor_name} sensor exists, but has a resolution of {sensor.event_resolution} instead of {event_resolution}. Please refer the 'October 1st 2025 go-live' instructions in `README.md`.")
+            current_app.logger.warning(
+                f"The {sensor_name} sensor exists, but has a resolution of {sensor.event_resolution} instead of {event_resolution}. Please refer the 'October 1st 2025 go-live' instructions in `README.md`."
+            )
         sensor.data_by_entsoe = data_by_entsoe
         sensors[sensor_name] = sensor
     if sensors_created:

--- a/requirements/app.in
+++ b/requirements/app.in
@@ -1,2 +1,3 @@
 # only listing extra dependencies that flexmeasures does not have
 entsoe-py
+timely-beliefs>=3.2.3


### PR DESCRIPTION
- [x] Automatically resample the ENTSO-E data to the resolution of your price sensor.
- [x] README section offering hosts two choices in preparation of the go-live moment on October 1st 2025.
- [x] Update dependency on `timely-beliefs`.