### PR TITLE
Import extra ENTSO-E regressors (residual load, outages, forecasts) for price forecasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,39 @@ Importing tomorrow's generation (incl. CO2 estimated content):
 Use ``--help`` to learn more usage details.
 
 
+### Importing extra regressors for price forecasting
+
+Research on the Dutch (NL) day-ahead market established that ENTSO-E day-ahead *fundamentals* dramatically improve day-ahead **price** forecasting, especially for hard cases (public holidays and the solar-driven midday price collapse):
+
+- **Residual load** (= day-ahead load forecast − day-ahead wind & solar forecast) is the single best regressor. Because the day-ahead *price* is formed against these very forecasts, residual load flattens the spurious holiday-morning price peak and captures the midday collapse.
+- **Generation outages** (day-ahead-known unavailable capacity) are a weaker, but physically relevant, regressor for scarcity.
+
+While importing day-ahead prices, you can *also* pull these regressor series, each into its own sensor (in MW). Choose what to import with the `--include-*` flags (all default to off):
+
+    flexmeasures entsoe import-day-ahead-prices \
+        --include-load-forecast \
+        --include-wind-solar-forecast \
+        --include-residual-load \
+        --include-outages
+
+The flags are independent, so you can import just what you need, e.g. only residual load:
+
+    flexmeasures entsoe import-day-ahead-prices --include-residual-load
+
+| Flag | Sensor(s) created/used | Unit | Source |
+| --- | --- | --- | --- |
+| `--include-load-forecast` | `Day-ahead load forecast` | MW | ENTSO-E |
+| `--include-wind-solar-forecast` | `Solar`, `Wind Onshore`, `Wind Offshore` (shared with the generation import) | MW | ENTSO-E |
+| `--include-residual-load` | `Residual load` | MW | derived (`ENTSOE_DERIVED_DATA_SOURCE`) |
+| `--include-outages` | `Generation outages` | MW | ENTSO-E |
+
+Notes:
+
+- `--include-residual-load` implies fetching both the load forecast and the wind & solar forecast (it needs them to derive residual load), but it only *saves* those series if their own flag is also set.
+- Each single-sensor regressor can be pointed at a specific existing sensor with `--load-forecast-sensor`, `--residual-load-sensor` and `--outages-sensor` (by sensor ID). Otherwise a sensibly-named sensor is created/looked up automatically.
+- **Generation outages and the day-ahead knowledge horizon.** For each target hour we sum the unavailable capacity (`nominal_power − avail_qty`) of every outage overlapping that hour, but *only* if the outage was **published (`created_doc_time`) before that hour's delivery day** (local midnight). Day-ahead prices are set with only the information known before the delivery day, so counting an outage announced on or after the delivery day would leak look-ahead information into the regressor. The publication time is checked per target hour, so a multi-day range aggregates correctly without leaking.
+
+
 ### October 1st 2025 go-live for ENTSO-E moving to 15-minute day-ahead prices
 
 ENTSO-E is moving from 1-hour day-ahead prices 15-minute day-ahead prices on October 1st 2025.

--- a/README.md
+++ b/README.md
@@ -42,17 +42,23 @@ The flags are independent, so you can import just what you need, e.g. only resid
 
     flexmeasures entsoe import-day-ahead-prices --include-residual-load
 
+Or use `--include-all` as a shorthand for "import everything" (all regressors *and* neighbours):
+
+    flexmeasures entsoe import-day-ahead-prices --include-all
+
 | Flag | Sensor(s) created/used | Unit | Source |
 | --- | --- | --- | --- |
 | `--include-load-forecast` | `Day-ahead load forecast` | MW | ENTSO-E |
 | `--include-wind-solar-forecast` | `Solar`, `Wind Onshore`, `Wind Offshore` (shared with the generation import) | MW | ENTSO-E |
 | `--include-residual-load` | `Residual load` | MW | derived (`ENTSOE_DERIVED_DATA_SOURCE`) |
 | `--include-outages` | `Generation outages` | MW | ENTSO-E |
-| `--include-neighbours` | The selected regressors above (except outages), per neighbour, e.g. `Residual load (DE_LU)` | MW | ENTSO-E / derived |
+| `--include-neighbours` | The selected regressors above (except outages), for each neighbour, on the neighbour's own transmission-zone asset | MW | ENTSO-E / derived |
+| `--include-all` | Shorthand: turns on all of the above (every regressor **and** `--include-neighbours`) | MW | ENTSO-E / derived |
 
 Notes:
 
 - `--include-residual-load` implies fetching both the load forecast and the wind & solar forecast (it needs them to derive residual load), but it only *saves* those series if their own flag is also set.
+- `--include-all` composes with the individual flags — setting it simply forces everything on.
 - Each single-sensor regressor can be pointed at a specific existing sensor with `--load-forecast-sensor`, `--residual-load-sensor` and `--outages-sensor` (by sensor ID). Otherwise a sensibly-named sensor is created/looked up automatically.
 - **Generation outages and the day-ahead knowledge horizon.** For each target hour we sum the unavailable capacity (`nominal_power − avail_qty`) of every outage overlapping that hour, but *only* if the outage was **published (`created_doc_time`) before that hour's delivery day** (local midnight). Day-ahead prices are set with only the information known before the delivery day, so counting an outage announced on or after the delivery day would leak look-ahead information into the regressor. The publication time is checked per target hour, so a multi-day range aggregates correctly without leaking.
 
@@ -64,10 +70,12 @@ Add `--include-neighbours` to *also* pull the selected regressors (all except ou
         --include-residual-load \
         --include-neighbours
 
-For NL, the neighbours are `DE_LU`, `BE`, `GB`, `NO_2` and `DK_1` (defined by interconnector in `INTERCONNECTED_NEIGHBOURS` in `flexmeasures_entsoe/prices/regressors.py`). Each neighbour's series is saved to a per-country sensor (e.g. `Residual load (DE_LU)`) under that neighbour's own transmission-zone asset.
+The neighbour set comes straight from ENTSO-E's own maintained mapping (`entsoe.mappings.NEIGHBOURS`), so it covers every country and tracks interconnection changes as the `entsoe-py` library is updated. For NL this yields `BE`, `DE_LU`, `DE_AT_LU`, `GB`, `NO_2` and `DK_1`.
 
-- Neighbour data is fetched **leniently**: if a neighbour publishes no data for a series (e.g. `NO_2` / `DK_1` have little or no wind & solar forecast), that series is skipped with a warning instead of aborting the import, and residual load simply falls back to the plain load forecast there.
-- The flag is defined per price country. Countries without a neighbour set (any country other than NL, for now) make `--include-neighbours` a harmless no-op — see the `TODO` in `regressors.py` to extend the mapping.
+Each neighbour's series are saved to **plainly-named** sensors (`Residual load`, `Day-ahead load forecast`, ...) that live on **that neighbour's own transmission-zone asset** and carry **that country's own timezone** (e.g. `Europe/London` for GB, `Europe/Oslo` for NO_2). So a country's identity comes from the asset, not from a name suffix: NL's `Residual load` and DE_LU's `Residual load` are distinct sensors on distinct assets.
+
+- Neighbour data is fetched **leniently**: if a neighbour publishes no data for a series (e.g. `NO_2` / `DK_1` have little or no wind & solar forecast, or a deprecated zone like `DE_AT_LU` has no day-ahead data), that series is skipped with a warning instead of aborting the import — and residual load simply falls back to the plain load forecast there. No empty sensors are created for series with no data.
+- Countries that ENTSO-E lists no neighbours for make `--include-neighbours` a harmless no-op.
 
 
 ### October 1st 2025 go-live for ENTSO-E moving to 15-minute day-ahead prices

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Research on the Dutch (NL) day-ahead market established that ENTSO-E day-ahead *
 
 - **Residual load** (= day-ahead load forecast − day-ahead wind & solar forecast) is the single best regressor. Because the day-ahead *price* is formed against these very forecasts, residual load flattens the spurious holiday-morning price peak and captures the midday collapse.
 - **Generation outages** (day-ahead-known unavailable capacity) are a weaker, but physically relevant, regressor for scarcity.
+- **Neighbouring countries' regressors** matter too: a €500+/MWh NL scarcity spike is usually a *regional* NW-European event (Germany, Belgium, Great Britain and the Nordics tight at the same time, so imports dry up). Neighbours' day-ahead residual-load forecasts measurably improve NL spike and evening-peak forecasts.
 
 While importing day-ahead prices, you can *also* pull these regressor series, each into its own sensor (in MW). Choose what to import with the `--include-*` flags (all default to off):
 
@@ -47,12 +48,26 @@ The flags are independent, so you can import just what you need, e.g. only resid
 | `--include-wind-solar-forecast` | `Solar`, `Wind Onshore`, `Wind Offshore` (shared with the generation import) | MW | ENTSO-E |
 | `--include-residual-load` | `Residual load` | MW | derived (`ENTSOE_DERIVED_DATA_SOURCE`) |
 | `--include-outages` | `Generation outages` | MW | ENTSO-E |
+| `--include-neighbours` | The selected regressors above (except outages), per neighbour, e.g. `Residual load (DE_LU)` | MW | ENTSO-E / derived |
 
 Notes:
 
 - `--include-residual-load` implies fetching both the load forecast and the wind & solar forecast (it needs them to derive residual load), but it only *saves* those series if their own flag is also set.
 - Each single-sensor regressor can be pointed at a specific existing sensor with `--load-forecast-sensor`, `--residual-load-sensor` and `--outages-sensor` (by sensor ID). Otherwise a sensibly-named sensor is created/looked up automatically.
 - **Generation outages and the day-ahead knowledge horizon.** For each target hour we sum the unavailable capacity (`nominal_power − avail_qty`) of every outage overlapping that hour, but *only* if the outage was **published (`created_doc_time`) before that hour's delivery day** (local midnight). Day-ahead prices are set with only the information known before the delivery day, so counting an outage announced on or after the delivery day would leak look-ahead information into the regressor. The publication time is checked per target hour, so a multi-day range aggregates correctly without leaking.
+
+#### Importing neighbours' regressors
+
+Add `--include-neighbours` to *also* pull the selected regressors (all except outages, which stay domestic-only) for the price country's interconnected neighbours:
+
+    flexmeasures entsoe import-day-ahead-prices \
+        --include-residual-load \
+        --include-neighbours
+
+For NL, the neighbours are `DE_LU`, `BE`, `GB`, `NO_2` and `DK_1` (defined by interconnector in `INTERCONNECTED_NEIGHBOURS` in `flexmeasures_entsoe/prices/regressors.py`). Each neighbour's series is saved to a per-country sensor (e.g. `Residual load (DE_LU)`) under that neighbour's own transmission-zone asset.
+
+- Neighbour data is fetched **leniently**: if a neighbour publishes no data for a series (e.g. `NO_2` / `DK_1` have little or no wind & solar forecast), that series is skipped with a warning instead of aborting the import, and residual load simply falls back to the plain load forecast there.
+- The flag is defined per price country. Countries without a neighbour set (any country other than NL, for now) make `--include-neighbours` a harmless no-op — see the `TODO` in `regressors.py` to extend the mapping.
 
 
 ### October 1st 2025 go-live for ENTSO-E moving to 15-minute day-ahead prices

--- a/flexmeasures_entsoe/__init__.py
+++ b/flexmeasures_entsoe/__init__.py
@@ -11,7 +11,7 @@ DEFAULT_COUNTRY_TIMEZONE = "Europe/Amsterdam"  # This is what we receive, even i
 DEFAULT_DATA_SOURCE_NAME = "ENTSO-E"
 DEFAULT_DERIVED_DATA_SOURCE = "FlexMeasures ENTSO-E"
 
-__version__ = "0.9"
+__version__ = "0.10"
 __settings__ = {
     "ENTSOE_AUTH_TOKEN": dict(
         description="You can generate this token after you made an account at ENTSO-E.",

--- a/flexmeasures_entsoe/prices/day_ahead.py
+++ b/flexmeasures_entsoe/prices/day_ahead.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 from datetime import datetime
 
 import click
@@ -13,7 +13,7 @@ from flexmeasures.data.schemas.sources import DataSourceIdField
 
 
 from . import pricing_sensors
-from . import regressors
+from .regressors_import import collect_and_save_regressors
 from .. import (
     entsoe_data_bp,
 )  # noqa: E402
@@ -21,7 +21,6 @@ from ..utils import (
     create_entsoe_client,
     ensure_country_code_and_timezone,
     ensure_data_source,
-    ensure_data_source_for_derived_data,
     parse_from_and_to_dates,
     ensure_sensors,
     save_entsoe_series,
@@ -77,6 +76,13 @@ from ..utils import (
     help="Source of the price data. If not provided, the source `ENTSO-E` is used.",
 )
 @click.option(
+    "--include-all/--no-include-all",
+    default=False,
+    help="Shorthand for 'import everything': turns on every regressor "
+    "(load forecast, wind & solar forecast, residual load, outages) AND --include-neighbours. "
+    "Combines with any explicitly set flags.",
+)
+@click.option(
     "--include-load-forecast/--no-include-load-forecast",
     default=False,
     help="Also import the ENTSO-E day-ahead load forecast into a `Day-ahead load forecast` sensor (MW).",
@@ -101,8 +107,9 @@ from ..utils import (
     "--include-neighbours/--no-include-neighbours",
     default=False,
     help="Also import the selected regressors (except outages) for interconnected neighbouring countries "
-    "(for NL: DE_LU, BE, GB, NO_2, DK_1), into per-country sensors (e.g. `Residual load (DE_LU)`). "
-    "Neighbour scarcity drives NL price spikes, so this improves spike/evening-peak forecasts.",
+    "(from ENTSO-E's own neighbour mapping; for NL: BE, DE_LU, DE_AT_LU, GB, NO_2, DK_1). "
+    "Each neighbour's series are saved to plainly-named sensors on that neighbour's own transmission-zone "
+    "asset. Neighbour scarcity drives NL price spikes, so this improves spike/evening-peak forecasts.",
 )
 @click.option(
     "--load-forecast-sensor",
@@ -150,6 +157,7 @@ def import_day_ahead_prices(
     country_timezone: Optional[str] = None,
     sensor: Optional[Sensor] = None,
     source: Optional[Source] = None,
+    include_all: bool = False,
     include_load_forecast: bool = False,
     include_wind_solar_forecast: bool = False,
     include_residual_load: bool = False,
@@ -171,6 +179,7 @@ def import_day_ahead_prices(
     saved to its own sensor (MW):
 
     \b
+      --include-all                  Shorthand: turn on all of the below (and neighbours).
       --include-load-forecast        ENTSO-E day-ahead load forecast.
       --include-wind-solar-forecast  ENTSO-E day-ahead wind & solar forecast
                                      (Solar, Wind Onshore, Wind Offshore).
@@ -182,10 +191,18 @@ def import_day_ahead_prices(
                                      Only outages published before a target hour's delivery
                                      day are counted, to avoid a look-ahead leak.
       --include-neighbours           Also import the selected regressors (except outages)
-                                     for interconnected neighbours, into per-country sensors
-                                     (e.g. `Residual load (DE_LU)`). Regional NW-European
-                                     scarcity drives NL price spikes.
+                                     for interconnected neighbours, on each neighbour's own
+                                     transmission-zone asset. Regional NW-European scarcity
+                                     drives NL price spikes.
     """
+    # --include-all is a shorthand that turns everything on; it composes with explicit flags.
+    if include_all:
+        include_load_forecast = True
+        include_wind_solar_forecast = True
+        include_residual_load = True
+        include_outages = True
+        include_neighbours = True
+
     # Set up FlexMeasures data structure
     country_code, country_timezone = ensure_country_code_and_timezone(
         country_code, country_timezone
@@ -259,311 +276,3 @@ def import_day_ahead_prices(
             residual_load_sensor=residual_load_sensor,
             outages_sensor=outages_sensor,
         )
-
-
-def collect_and_save_regressors(
-    client,
-    log,
-    dryrun: bool,
-    country_code: str,
-    country_timezone: str,
-    from_time: pd.Timestamp,
-    until_time: pd.Timestamp,
-    now: datetime,
-    entsoe_data_source: Source,
-    include_load_forecast: bool,
-    include_wind_solar_forecast: bool,
-    include_residual_load: bool,
-    include_outages: bool,
-    include_neighbours: bool = False,
-    load_forecast_sensor: Optional[Sensor] = None,
-    residual_load_sensor: Optional[Sensor] = None,
-    outages_sensor: Optional[Sensor] = None,
-):
-    """
-    Query and save the requested extra regressor series (each to its own sensor).
-
-    Data is only fetched from ENTSO-E when needed: residual load implies fetching the
-    load and wind & solar forecasts, even when those are not saved themselves.
-
-    When ``include_neighbours`` is set, the same regressors (except domestic outages) are
-    also collected for the price country's interconnected neighbours, saved to per-country
-    sensors (e.g. ``Residual load (DE_LU)``) under each neighbour's own transmission zone.
-    Missing neighbour data is skipped gracefully rather than aborting the import.
-    """
-    # Collect the domestic (price-country) regressors. This is strict: if ENTSO-E has no
-    # data for the price country itself, we abort (as the price import already does).
-    to_save = _collect_country_regressors(
-        client=client,
-        log=log,
-        data_country_code=country_code,
-        sensor_timezone=country_timezone,
-        from_time=from_time,
-        until_time=until_time,
-        include_load_forecast=include_load_forecast,
-        include_wind_solar_forecast=include_wind_solar_forecast,
-        include_residual_load=include_residual_load,
-        include_outages=include_outages,
-        suffix="",
-        strict=True,
-        load_forecast_sensor=load_forecast_sensor,
-        residual_load_sensor=residual_load_sensor,
-        outages_sensor=outages_sensor,
-    )
-
-    # Optionally, collect the same regressors (minus outages) for each neighbour. This is
-    # lenient: neighbours with no published data (e.g. no wind & solar for NO_2 / DK_1)
-    # are skipped, and residual load then falls back to the plain load forecast.
-    if include_neighbours:
-        neighbours = regressors.INTERCONNECTED_NEIGHBOURS.get(country_code, [])
-        if not neighbours:
-            log.warning(
-                f"No interconnected neighbours are defined for {country_code}; "
-                "--include-neighbours has no effect."
-            )
-        for neighbour in neighbours:
-            log.info(f"Collecting regressors for neighbour {neighbour} ...")
-            to_save += _collect_country_regressors(
-                client=client,
-                log=log,
-                data_country_code=neighbour,
-                sensor_timezone=country_timezone,
-                from_time=from_time,
-                until_time=until_time,
-                include_load_forecast=include_load_forecast,
-                include_wind_solar_forecast=include_wind_solar_forecast,
-                include_residual_load=include_residual_load,
-                include_outages=False,  # outages stay domestic-only
-                suffix=f" ({neighbour})",
-                strict=False,
-            )
-
-    if not dryrun:
-        _save_regressor_series(to_save, log, entsoe_data_source, country_timezone, now)
-
-
-def _collect_country_regressors(
-    client,
-    log,
-    data_country_code: str,
-    sensor_timezone: str,
-    from_time: pd.Timestamp,
-    until_time: pd.Timestamp,
-    include_load_forecast: bool,
-    include_wind_solar_forecast: bool,
-    include_residual_load: bool,
-    include_outages: bool,
-    suffix: str = "",
-    strict: bool = True,
-    load_forecast_sensor: Optional[Sensor] = None,
-    residual_load_sensor: Optional[Sensor] = None,
-    outages_sensor: Optional[Sensor] = None,
-) -> List[Tuple[Sensor, pd.Series, bool]]:
-    """Collect the (sensor, series, is_entsoe_data) triples for one country's regressors.
-
-    ``data_country_code`` is queried at ENTSO-E; the sensors are named with ``suffix``
-    (empty for the price country, e.g. " (DE_LU)" for a neighbour) and live under that
-    country's own transmission zone. With ``strict=False`` (used for neighbours), missing
-    data is skipped with a warning instead of aborting the whole import.
-    """
-    ensured_sensors = _ensure_regressor_sensors(
-        country_code=data_country_code,
-        country_timezone=sensor_timezone,
-        include_load_forecast=include_load_forecast and load_forecast_sensor is None,
-        include_wind_solar_forecast=include_wind_solar_forecast,
-        include_residual_load=include_residual_load and residual_load_sensor is None,
-        include_outages=include_outages and outages_sensor is None,
-        suffix=suffix,
-    )
-
-    # Query ENTSO-E only for what we need (residual load implies both forecasts).
-    load_series = None
-    green_forecast = None
-    if include_load_forecast or include_residual_load:
-        load_forecast = _query_series(
-            lambda: client.query_load_forecast(
-                data_country_code, start=from_time, end=until_time
-            ),
-            strict=strict,
-            log=log,
-            description=f"day-ahead load forecast for {data_country_code}",
-        )
-        if load_forecast is not None:
-            load_series = regressors.load_series_from_forecast(load_forecast)
-            log.debug("Load forecast: \n%s" % load_series)
-    if include_wind_solar_forecast or include_residual_load:
-        green_forecast = _query_series(
-            lambda: client.query_wind_and_solar_forecast(
-                data_country_code, start=from_time, end=until_time, psr_type=None
-            ),
-            strict=strict,
-            log=log,
-            description=f"day-ahead wind & solar forecast for {data_country_code}",
-        )
-        if green_forecast is not None:
-            log.debug("Wind & solar forecast: \n%s" % green_forecast)
-
-    # Assemble the (sensor, series, is_entsoe_data) triples to save.
-    to_save: List[Tuple[Sensor, pd.Series, bool]] = []
-    if include_load_forecast and load_series is not None:
-        sensor = (
-            load_forecast_sensor or ensured_sensors["Day-ahead load forecast" + suffix]
-        )
-        to_save.append((sensor, load_series, True))
-    if include_wind_solar_forecast and green_forecast is not None:
-        to_save.extend(
-            _wind_solar_to_save(
-                green_forecast, ensured_sensors, data_country_code, suffix, log
-            )
-        )
-    if include_residual_load:
-        if load_series is None:
-            log.warning(
-                f"No load forecast for {data_country_code}; cannot derive residual load. Skipping."
-            )
-        else:
-            residual_load = _build_residual_load(load_series, green_forecast, log)
-            sensor = residual_load_sensor or ensured_sensors["Residual load" + suffix]
-            to_save.append((sensor, residual_load, False))
-    if include_outages:
-        log.info("Getting generation outages (unavailable capacity) ...")
-        outages = client.query_unavailability_of_generation_units(
-            data_country_code, start=from_time, end=until_time
-        )
-        # Note: outages may legitimately be empty (no announced outages), so we do not abort.
-        unavailable_mw = regressors.aggregate_outages_to_hourly_unavailable_mw(
-            outages, from_time, until_time
-        )
-        log.debug("Hourly unavailable capacity (MW): \n%s" % unavailable_mw)
-        sensor = outages_sensor or ensured_sensors["Generation outages" + suffix]
-        to_save.append((sensor, unavailable_mw, True))
-    return to_save
-
-
-def _query_series(client_call, strict: bool, log, description: str):
-    """Run an ENTSO-E query, returning None on missing data when not strict.
-
-    In strict mode (price country) an empty result aborts, matching the price import.
-    In lenient mode (neighbours) both a raised exception (e.g. entsoe's NoMatchingDataError)
-    and an empty result are turned into a warning + None, so one missing neighbour series
-    never crashes the import.
-    """
-    try:
-        data = client_call()
-    except (
-        Exception
-    ) as e:  # noqa: B902 - any ENTSO-E failure for a neighbour is non-fatal
-        if strict:
-            raise
-        log.warning(f"Could not get {description} ({e}); skipping.")
-        return None
-    if data is None or (hasattr(data, "empty") and data.empty):
-        if strict:
-            abort_if_data_empty(data)  # raises click.Abort
-        log.warning(f"No {description} available; skipping.")
-        return None
-    return data
-
-
-def _ensure_regressor_sensors(
-    country_code: str,
-    country_timezone: str,
-    include_load_forecast: bool,
-    include_wind_solar_forecast: bool,
-    include_residual_load: bool,
-    include_outages: bool,
-    suffix: str = "",
-) -> Dict[str, Sensor]:
-    """Ensure the sensors for the requested regressors exist, returning them by name.
-
-    ``suffix`` is appended to each sensor name (e.g. " (DE_LU)") so neighbour regressors
-    get their own per-country sensors.
-    """
-    specs: List[Tuple] = []
-    if include_load_forecast:
-        specs.append(_suffix_spec(regressors.LOAD_FORECAST_SENSOR_SPEC, suffix))
-    if include_wind_solar_forecast:
-        specs.extend(
-            _suffix_spec(spec, suffix) for spec in regressors.WIND_SOLAR_SENSOR_SPECS
-        )
-    if include_residual_load:
-        specs.append(_suffix_spec(regressors.RESIDUAL_LOAD_SENSOR_SPEC, suffix))
-    if include_outages:
-        specs.append(_suffix_spec(regressors.OUTAGES_SENSOR_SPEC, suffix))
-    if not specs:
-        return {}
-    return ensure_sensors(tuple(specs), country_code, country_timezone)
-
-
-def _suffix_spec(spec: Tuple, suffix: str) -> Tuple:
-    """Append ``suffix`` to a sensor spec's name, leaving unit/resolution/source as-is."""
-    name, unit, event_resolution, data_by_entsoe = spec
-    return (name + suffix, unit, event_resolution, data_by_entsoe)
-
-
-def _wind_solar_to_save(
-    green_forecast: pd.DataFrame,
-    ensured_sensors: Dict[str, Sensor],
-    country_code: str,
-    suffix: str,
-    log,
-) -> List[Tuple[Sensor, pd.Series, bool]]:
-    """Pair each reported green column with its sensor (skipping columns not reported)."""
-    triples: List[Tuple[Sensor, pd.Series, bool]] = []
-    for column in regressors.GREEN_COLUMNS:
-        series = regressors.green_column(green_forecast, column)
-        if series is None:
-            log.warning(
-                f"ENTSO-E did not report '{column}' for {country_code}; skipping that sensor."
-            )
-            continue
-        triples.append((ensured_sensors[column + suffix], series, True))
-    return triples
-
-
-def _build_residual_load(
-    load_series: pd.Series, green_forecast: Optional[pd.DataFrame], log
-) -> pd.Series:
-    """Derive residual load, aligning all inputs to hourly means first.
-
-    ``green_forecast`` may be None (no wind & solar published for this country), in which
-    case residual load falls back to the plain load forecast.
-    """
-    log.info("Computing residual load (load − wind & solar) ...")
-
-    def to_hourly(series: Optional[pd.Series]) -> pd.Series:
-        if series is None or series.empty:
-            return pd.Series(dtype="float64")
-        return series.resample("1h").mean()
-
-    residual_load = regressors.compute_residual_load(
-        load_forecast=to_hourly(load_series),
-        solar=to_hourly(regressors.green_column(green_forecast, "Solar")),
-        wind_offshore=to_hourly(
-            regressors.green_column(green_forecast, "Wind Offshore")
-        ),
-        wind_onshore=to_hourly(regressors.green_column(green_forecast, "Wind Onshore")),
-    )
-    log.debug("Residual load: \n%s" % residual_load)
-    return residual_load
-
-
-def _save_regressor_series(
-    to_save: List[Tuple[Sensor, pd.Series, bool]],
-    log,
-    entsoe_data_source: Source,
-    country_timezone: str,
-    now: datetime,
-):
-    """Save each regressor series, using the derived data source for derived series."""
-    derived_data_source = None  # created lazily, only if we save derived data
-    for sensor, series, is_entsoe_data in to_save:
-        series = resample_if_needed(series, sensor)
-        if is_entsoe_data:
-            regressor_source = entsoe_data_source
-        else:
-            if derived_data_source is None:
-                derived_data_source = ensure_data_source_for_derived_data()
-            regressor_source = derived_data_source
-        log.info(f"Saving {len(series)} beliefs for Sensor {sensor.name} ...")
-        save_entsoe_series(series, sensor, regressor_source, country_timezone, now)

--- a/flexmeasures_entsoe/prices/day_ahead.py
+++ b/flexmeasures_entsoe/prices/day_ahead.py
@@ -97,6 +97,13 @@ from ..utils import (
     help="Also import day-ahead-known generation outages (unavailable capacity) into a `Generation outages` sensor (MW).",
 )
 @click.option(
+    "--include-neighbours/--no-include-neighbours",
+    default=False,
+    help="Also import the selected regressors (except outages) for interconnected neighbouring countries "
+    "(for NL: DE_LU, BE, GB, NO_2, DK_1), into per-country sensors (e.g. `Residual load (DE_LU)`). "
+    "Neighbour scarcity drives NL price spikes, so this improves spike/evening-peak forecasts.",
+)
+@click.option(
     "--load-forecast-sensor",
     "load_forecast_sensor",
     type=SensorIdField(),
@@ -131,6 +138,7 @@ def import_day_ahead_prices(
     include_wind_solar_forecast: bool = False,
     include_residual_load: bool = False,
     include_outages: bool = False,
+    include_neighbours: bool = False,
     load_forecast_sensor: Optional[Sensor] = None,
     residual_load_sensor: Optional[Sensor] = None,
     outages_sensor: Optional[Sensor] = None,
@@ -155,6 +163,10 @@ def import_day_ahead_prices(
       --include-outages              Day-ahead-known generation outages (unavailable MW).
                                      Only outages published before a target hour's delivery
                                      day are counted, to avoid a look-ahead leak.
+      --include-neighbours           Also import the selected regressors (except outages)
+                                     for interconnected neighbours, into per-country sensors
+                                     (e.g. `Residual load (DE_LU)`). Regional NW-European
+                                     scarcity drives NL price spikes.
     """
     # Set up FlexMeasures data structure
     country_code, country_timezone = ensure_country_code_and_timezone(
@@ -220,6 +232,7 @@ def import_day_ahead_prices(
             include_wind_solar_forecast=include_wind_solar_forecast,
             include_residual_load=include_residual_load,
             include_outages=include_outages,
+            include_neighbours=include_neighbours,
             load_forecast_sensor=load_forecast_sensor,
             residual_load_sensor=residual_load_sensor,
             outages_sensor=outages_sensor,
@@ -240,6 +253,7 @@ def collect_and_save_regressors(
     include_wind_solar_forecast: bool,
     include_residual_load: bool,
     include_outages: bool,
+    include_neighbours: bool = False,
     load_forecast_sensor: Optional[Sensor] = None,
     residual_load_sensor: Optional[Sensor] = None,
     outages_sensor: Optional[Sensor] = None,
@@ -249,63 +263,184 @@ def collect_and_save_regressors(
 
     Data is only fetched from ENTSO-E when needed: residual load implies fetching the
     load and wind & solar forecasts, even when those are not saved themselves.
+
+    When ``include_neighbours`` is set, the same regressors (except domestic outages) are
+    also collected for the price country's interconnected neighbours, saved to per-country
+    sensors (e.g. ``Residual load (DE_LU)``) under each neighbour's own transmission zone.
+    Missing neighbour data is skipped gracefully rather than aborting the import.
     """
-    # Ensure/lookup the sensors we will write to.
+    # Collect the domestic (price-country) regressors. This is strict: if ENTSO-E has no
+    # data for the price country itself, we abort (as the price import already does).
+    to_save = _collect_country_regressors(
+        client=client,
+        log=log,
+        data_country_code=country_code,
+        sensor_timezone=country_timezone,
+        from_time=from_time,
+        until_time=until_time,
+        include_load_forecast=include_load_forecast,
+        include_wind_solar_forecast=include_wind_solar_forecast,
+        include_residual_load=include_residual_load,
+        include_outages=include_outages,
+        suffix="",
+        strict=True,
+        load_forecast_sensor=load_forecast_sensor,
+        residual_load_sensor=residual_load_sensor,
+        outages_sensor=outages_sensor,
+    )
+
+    # Optionally, collect the same regressors (minus outages) for each neighbour. This is
+    # lenient: neighbours with no published data (e.g. no wind & solar for NO_2 / DK_1)
+    # are skipped, and residual load then falls back to the plain load forecast.
+    if include_neighbours:
+        neighbours = regressors.INTERCONNECTED_NEIGHBOURS.get(country_code, [])
+        if not neighbours:
+            log.warning(
+                f"No interconnected neighbours are defined for {country_code}; "
+                "--include-neighbours has no effect."
+            )
+        for neighbour in neighbours:
+            log.info(f"Collecting regressors for neighbour {neighbour} ...")
+            to_save += _collect_country_regressors(
+                client=client,
+                log=log,
+                data_country_code=neighbour,
+                sensor_timezone=country_timezone,
+                from_time=from_time,
+                until_time=until_time,
+                include_load_forecast=include_load_forecast,
+                include_wind_solar_forecast=include_wind_solar_forecast,
+                include_residual_load=include_residual_load,
+                include_outages=False,  # outages stay domestic-only
+                suffix=f" ({neighbour})",
+                strict=False,
+            )
+
+    if not dryrun:
+        _save_regressor_series(to_save, log, entsoe_data_source, country_timezone, now)
+
+
+def _collect_country_regressors(
+    client,
+    log,
+    data_country_code: str,
+    sensor_timezone: str,
+    from_time: pd.Timestamp,
+    until_time: pd.Timestamp,
+    include_load_forecast: bool,
+    include_wind_solar_forecast: bool,
+    include_residual_load: bool,
+    include_outages: bool,
+    suffix: str = "",
+    strict: bool = True,
+    load_forecast_sensor: Optional[Sensor] = None,
+    residual_load_sensor: Optional[Sensor] = None,
+    outages_sensor: Optional[Sensor] = None,
+) -> List[Tuple[Sensor, pd.Series, bool]]:
+    """Collect the (sensor, series, is_entsoe_data) triples for one country's regressors.
+
+    ``data_country_code`` is queried at ENTSO-E; the sensors are named with ``suffix``
+    (empty for the price country, e.g. " (DE_LU)" for a neighbour) and live under that
+    country's own transmission zone. With ``strict=False`` (used for neighbours), missing
+    data is skipped with a warning instead of aborting the whole import.
+    """
     ensured_sensors = _ensure_regressor_sensors(
-        country_code=country_code,
-        country_timezone=country_timezone,
+        country_code=data_country_code,
+        country_timezone=sensor_timezone,
         include_load_forecast=include_load_forecast and load_forecast_sensor is None,
         include_wind_solar_forecast=include_wind_solar_forecast,
         include_residual_load=include_residual_load and residual_load_sensor is None,
         include_outages=include_outages and outages_sensor is None,
+        suffix=suffix,
     )
 
     # Query ENTSO-E only for what we need (residual load implies both forecasts).
-    load_series = green_forecast = None
+    load_series = None
+    green_forecast = None
     if include_load_forecast or include_residual_load:
-        log.info("Getting day-ahead load forecast ...")
-        load_forecast = client.query_load_forecast(
-            country_code, start=from_time, end=until_time
+        load_forecast = _query_series(
+            lambda: client.query_load_forecast(
+                data_country_code, start=from_time, end=until_time
+            ),
+            strict=strict,
+            log=log,
+            description=f"day-ahead load forecast for {data_country_code}",
         )
-        abort_if_data_empty(load_forecast)
-        load_series = regressors.load_series_from_forecast(load_forecast)
-        log.debug("Load forecast: \n%s" % load_series)
+        if load_forecast is not None:
+            load_series = regressors.load_series_from_forecast(load_forecast)
+            log.debug("Load forecast: \n%s" % load_series)
     if include_wind_solar_forecast or include_residual_load:
-        log.info("Getting day-ahead wind & solar forecast ...")
-        green_forecast = client.query_wind_and_solar_forecast(
-            country_code, start=from_time, end=until_time, psr_type=None
+        green_forecast = _query_series(
+            lambda: client.query_wind_and_solar_forecast(
+                data_country_code, start=from_time, end=until_time, psr_type=None
+            ),
+            strict=strict,
+            log=log,
+            description=f"day-ahead wind & solar forecast for {data_country_code}",
         )
-        abort_if_data_empty(green_forecast)
-        log.debug("Wind & solar forecast: \n%s" % green_forecast)
+        if green_forecast is not None:
+            log.debug("Wind & solar forecast: \n%s" % green_forecast)
 
     # Assemble the (sensor, series, is_entsoe_data) triples to save.
     to_save: List[Tuple[Sensor, pd.Series, bool]] = []
-    if include_load_forecast:
-        sensor = load_forecast_sensor or ensured_sensors["Day-ahead load forecast"]
+    if include_load_forecast and load_series is not None:
+        sensor = (
+            load_forecast_sensor or ensured_sensors["Day-ahead load forecast" + suffix]
+        )
         to_save.append((sensor, load_series, True))
-    if include_wind_solar_forecast:
+    if include_wind_solar_forecast and green_forecast is not None:
         to_save.extend(
-            _wind_solar_to_save(green_forecast, ensured_sensors, country_code, log)
+            _wind_solar_to_save(
+                green_forecast, ensured_sensors, data_country_code, suffix, log
+            )
         )
     if include_residual_load:
-        residual_load = _build_residual_load(load_series, green_forecast, log)
-        sensor = residual_load_sensor or ensured_sensors["Residual load"]
-        to_save.append((sensor, residual_load, False))
+        if load_series is None:
+            log.warning(
+                f"No load forecast for {data_country_code}; cannot derive residual load. Skipping."
+            )
+        else:
+            residual_load = _build_residual_load(load_series, green_forecast, log)
+            sensor = residual_load_sensor or ensured_sensors["Residual load" + suffix]
+            to_save.append((sensor, residual_load, False))
     if include_outages:
         log.info("Getting generation outages (unavailable capacity) ...")
         outages = client.query_unavailability_of_generation_units(
-            country_code, start=from_time, end=until_time
+            data_country_code, start=from_time, end=until_time
         )
         # Note: outages may legitimately be empty (no announced outages), so we do not abort.
         unavailable_mw = regressors.aggregate_outages_to_hourly_unavailable_mw(
             outages, from_time, until_time
         )
         log.debug("Hourly unavailable capacity (MW): \n%s" % unavailable_mw)
-        sensor = outages_sensor or ensured_sensors["Generation outages"]
+        sensor = outages_sensor or ensured_sensors["Generation outages" + suffix]
         to_save.append((sensor, unavailable_mw, True))
+    return to_save
 
-    if not dryrun:
-        _save_regressor_series(to_save, log, entsoe_data_source, country_timezone, now)
+
+def _query_series(client_call, strict: bool, log, description: str):
+    """Run an ENTSO-E query, returning None on missing data when not strict.
+
+    In strict mode (price country) an empty result aborts, matching the price import.
+    In lenient mode (neighbours) both a raised exception (e.g. entsoe's NoMatchingDataError)
+    and an empty result are turned into a warning + None, so one missing neighbour series
+    never crashes the import.
+    """
+    try:
+        data = client_call()
+    except (
+        Exception
+    ) as e:  # noqa: B902 - any ENTSO-E failure for a neighbour is non-fatal
+        if strict:
+            raise
+        log.warning(f"Could not get {description} ({e}); skipping.")
+        return None
+    if data is None or (hasattr(data, "empty") and data.empty):
+        if strict:
+            abort_if_data_empty(data)  # raises click.Abort
+        log.warning(f"No {description} available; skipping.")
+        return None
+    return data
 
 
 def _ensure_regressor_sensors(
@@ -315,26 +450,40 @@ def _ensure_regressor_sensors(
     include_wind_solar_forecast: bool,
     include_residual_load: bool,
     include_outages: bool,
+    suffix: str = "",
 ) -> Dict[str, Sensor]:
-    """Ensure the sensors for the requested regressors exist, returning them by name."""
+    """Ensure the sensors for the requested regressors exist, returning them by name.
+
+    ``suffix`` is appended to each sensor name (e.g. " (DE_LU)") so neighbour regressors
+    get their own per-country sensors.
+    """
     specs: List[Tuple] = []
     if include_load_forecast:
-        specs.append(regressors.LOAD_FORECAST_SENSOR_SPEC)
+        specs.append(_suffix_spec(regressors.LOAD_FORECAST_SENSOR_SPEC, suffix))
     if include_wind_solar_forecast:
-        specs.extend(regressors.WIND_SOLAR_SENSOR_SPECS)
+        specs.extend(
+            _suffix_spec(spec, suffix) for spec in regressors.WIND_SOLAR_SENSOR_SPECS
+        )
     if include_residual_load:
-        specs.append(regressors.RESIDUAL_LOAD_SENSOR_SPEC)
+        specs.append(_suffix_spec(regressors.RESIDUAL_LOAD_SENSOR_SPEC, suffix))
     if include_outages:
-        specs.append(regressors.OUTAGES_SENSOR_SPEC)
+        specs.append(_suffix_spec(regressors.OUTAGES_SENSOR_SPEC, suffix))
     if not specs:
         return {}
     return ensure_sensors(tuple(specs), country_code, country_timezone)
+
+
+def _suffix_spec(spec: Tuple, suffix: str) -> Tuple:
+    """Append ``suffix`` to a sensor spec's name, leaving unit/resolution/source as-is."""
+    name, unit, event_resolution, data_by_entsoe = spec
+    return (name + suffix, unit, event_resolution, data_by_entsoe)
 
 
 def _wind_solar_to_save(
     green_forecast: pd.DataFrame,
     ensured_sensors: Dict[str, Sensor],
     country_code: str,
+    suffix: str,
     log,
 ) -> List[Tuple[Sensor, pd.Series, bool]]:
     """Pair each reported green column with its sensor (skipping columns not reported)."""
@@ -346,14 +495,18 @@ def _wind_solar_to_save(
                 f"ENTSO-E did not report '{column}' for {country_code}; skipping that sensor."
             )
             continue
-        triples.append((ensured_sensors[column], series, True))
+        triples.append((ensured_sensors[column + suffix], series, True))
     return triples
 
 
 def _build_residual_load(
-    load_series: pd.Series, green_forecast: pd.DataFrame, log
+    load_series: pd.Series, green_forecast: Optional[pd.DataFrame], log
 ) -> pd.Series:
-    """Derive residual load, aligning all inputs to hourly means first."""
+    """Derive residual load, aligning all inputs to hourly means first.
+
+    ``green_forecast`` may be None (no wind & solar published for this country), in which
+    case residual load falls back to the plain load forecast.
+    """
     log.info("Computing residual load (load − wind & solar) ...")
 
     def to_hourly(series: Optional[pd.Series]) -> pd.Series:

--- a/flexmeasures_entsoe/prices/day_ahead.py
+++ b/flexmeasures_entsoe/prices/day_ahead.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, List, Optional, Tuple
 from datetime import datetime
 
 import click
@@ -13,6 +13,7 @@ from flexmeasures.data.schemas.sources import DataSourceIdField
 
 
 from . import pricing_sensors
+from . import regressors
 from .. import (
     entsoe_data_bp,
 )  # noqa: E402
@@ -20,6 +21,7 @@ from ..utils import (
     create_entsoe_client,
     ensure_country_code_and_timezone,
     ensure_data_source,
+    ensure_data_source_for_derived_data,
     parse_from_and_to_dates_default_today_and_tomorrow,
     ensure_sensors,
     save_entsoe_series,
@@ -73,6 +75,48 @@ from ..utils import (
     required=False,
     help="Source of the price data. If not provided, the source `ENTSO-E` is used.",
 )
+@click.option(
+    "--include-load-forecast/--no-include-load-forecast",
+    default=False,
+    help="Also import the ENTSO-E day-ahead load forecast into a `Day-ahead load forecast` sensor (MW).",
+)
+@click.option(
+    "--include-wind-solar-forecast/--no-include-wind-solar-forecast",
+    default=False,
+    help="Also import the ENTSO-E day-ahead wind & solar forecast into the `Solar`, `Wind Onshore` and `Wind Offshore` sensors (MW).",
+)
+@click.option(
+    "--include-residual-load/--no-include-residual-load",
+    default=False,
+    help="Also derive and import residual load (load forecast − wind & solar forecast) into a `Residual load` sensor (MW). "
+    "The strongest single regressor for day-ahead prices. Implies fetching the load and wind & solar forecasts.",
+)
+@click.option(
+    "--include-outages/--no-include-outages",
+    default=False,
+    help="Also import day-ahead-known generation outages (unavailable capacity) into a `Generation outages` sensor (MW).",
+)
+@click.option(
+    "--load-forecast-sensor",
+    "load_forecast_sensor",
+    type=SensorIdField(),
+    required=False,
+    help="Sensor to store the load forecast into. Defaults to the `Day-ahead load forecast` sensor.",
+)
+@click.option(
+    "--residual-load-sensor",
+    "residual_load_sensor",
+    type=SensorIdField(),
+    required=False,
+    help="Sensor to store residual load into. Defaults to the `Residual load` sensor.",
+)
+@click.option(
+    "--outages-sensor",
+    "outages_sensor",
+    type=SensorIdField(),
+    required=False,
+    help="Sensor to store generation outages into. Defaults to the `Generation outages` sensor.",
+)
 @with_appcontext
 @task_with_status_report("entsoe-import-day-ahead-prices")
 def import_day_ahead_prices(
@@ -83,11 +127,34 @@ def import_day_ahead_prices(
     country_timezone: Optional[str] = None,
     sensor: Optional[Sensor] = None,
     source: Optional[Source] = None,
+    include_load_forecast: bool = False,
+    include_wind_solar_forecast: bool = False,
+    include_residual_load: bool = False,
+    include_outages: bool = False,
+    load_forecast_sensor: Optional[Sensor] = None,
+    residual_load_sensor: Optional[Sensor] = None,
+    outages_sensor: Optional[Sensor] = None,
 ):
     """
     Import forecasted prices for any date range, defaulting to today and tomorrow.
     Possibly best to run this script somewhere around or maybe two or three hours after 13:00,
     when tomorrow's prices are announced.
+
+    Optionally, also import extra regressor series that improve day-ahead *price*
+    forecasting. Use the --include-* flags to choose which of these to pull; each is
+    saved to its own sensor (MW):
+
+    \b
+      --include-load-forecast        ENTSO-E day-ahead load forecast.
+      --include-wind-solar-forecast  ENTSO-E day-ahead wind & solar forecast
+                                     (Solar, Wind Onshore, Wind Offshore).
+      --include-residual-load        Residual load = load forecast − wind & solar
+                                     forecast. The single strongest regressor for NL
+                                     day-ahead prices. Implies fetching the two forecasts
+                                     above (but only saves them if their own flag is set).
+      --include-outages              Day-ahead-known generation outages (unavailable MW).
+                                     Only outages published before a target hour's delivery
+                                     day are counted, to avoid a look-ahead leak.
     """
     # Set up FlexMeasures data structure
     country_code, country_timezone = ensure_country_code_and_timezone(
@@ -131,3 +198,197 @@ def import_day_ahead_prices(
         save_entsoe_series(
             prices, pricing_sensor, entsoe_data_source, country_timezone, now
         )
+
+    # Optionally, import extra regressor series for price forecasting.
+    if (
+        include_load_forecast
+        or include_wind_solar_forecast
+        or include_residual_load
+        or include_outages
+    ):
+        collect_and_save_regressors(
+            client=client,
+            log=log,
+            dryrun=dryrun,
+            country_code=country_code,
+            country_timezone=country_timezone,
+            from_time=from_time,
+            until_time=until_time,
+            now=now,
+            entsoe_data_source=entsoe_data_source,
+            include_load_forecast=include_load_forecast,
+            include_wind_solar_forecast=include_wind_solar_forecast,
+            include_residual_load=include_residual_load,
+            include_outages=include_outages,
+            load_forecast_sensor=load_forecast_sensor,
+            residual_load_sensor=residual_load_sensor,
+            outages_sensor=outages_sensor,
+        )
+
+
+def collect_and_save_regressors(
+    client,
+    log,
+    dryrun: bool,
+    country_code: str,
+    country_timezone: str,
+    from_time: pd.Timestamp,
+    until_time: pd.Timestamp,
+    now: datetime,
+    entsoe_data_source: Source,
+    include_load_forecast: bool,
+    include_wind_solar_forecast: bool,
+    include_residual_load: bool,
+    include_outages: bool,
+    load_forecast_sensor: Optional[Sensor] = None,
+    residual_load_sensor: Optional[Sensor] = None,
+    outages_sensor: Optional[Sensor] = None,
+):
+    """
+    Query and save the requested extra regressor series (each to its own sensor).
+
+    Data is only fetched from ENTSO-E when needed: residual load implies fetching the
+    load and wind & solar forecasts, even when those are not saved themselves.
+    """
+    # Ensure/lookup the sensors we will write to.
+    ensured_sensors = _ensure_regressor_sensors(
+        country_code=country_code,
+        country_timezone=country_timezone,
+        include_load_forecast=include_load_forecast and load_forecast_sensor is None,
+        include_wind_solar_forecast=include_wind_solar_forecast,
+        include_residual_load=include_residual_load and residual_load_sensor is None,
+        include_outages=include_outages and outages_sensor is None,
+    )
+
+    # Query ENTSO-E only for what we need (residual load implies both forecasts).
+    load_series = green_forecast = None
+    if include_load_forecast or include_residual_load:
+        log.info("Getting day-ahead load forecast ...")
+        load_forecast = client.query_load_forecast(
+            country_code, start=from_time, end=until_time
+        )
+        abort_if_data_empty(load_forecast)
+        load_series = regressors.load_series_from_forecast(load_forecast)
+        log.debug("Load forecast: \n%s" % load_series)
+    if include_wind_solar_forecast or include_residual_load:
+        log.info("Getting day-ahead wind & solar forecast ...")
+        green_forecast = client.query_wind_and_solar_forecast(
+            country_code, start=from_time, end=until_time, psr_type=None
+        )
+        abort_if_data_empty(green_forecast)
+        log.debug("Wind & solar forecast: \n%s" % green_forecast)
+
+    # Assemble the (sensor, series, is_entsoe_data) triples to save.
+    to_save: List[Tuple[Sensor, pd.Series, bool]] = []
+    if include_load_forecast:
+        sensor = load_forecast_sensor or ensured_sensors["Day-ahead load forecast"]
+        to_save.append((sensor, load_series, True))
+    if include_wind_solar_forecast:
+        to_save.extend(
+            _wind_solar_to_save(green_forecast, ensured_sensors, country_code, log)
+        )
+    if include_residual_load:
+        residual_load = _build_residual_load(load_series, green_forecast, log)
+        sensor = residual_load_sensor or ensured_sensors["Residual load"]
+        to_save.append((sensor, residual_load, False))
+    if include_outages:
+        log.info("Getting generation outages (unavailable capacity) ...")
+        outages = client.query_unavailability_of_generation_units(
+            country_code, start=from_time, end=until_time
+        )
+        # Note: outages may legitimately be empty (no announced outages), so we do not abort.
+        unavailable_mw = regressors.aggregate_outages_to_hourly_unavailable_mw(
+            outages, from_time, until_time
+        )
+        log.debug("Hourly unavailable capacity (MW): \n%s" % unavailable_mw)
+        sensor = outages_sensor or ensured_sensors["Generation outages"]
+        to_save.append((sensor, unavailable_mw, True))
+
+    if not dryrun:
+        _save_regressor_series(to_save, log, entsoe_data_source, country_timezone, now)
+
+
+def _ensure_regressor_sensors(
+    country_code: str,
+    country_timezone: str,
+    include_load_forecast: bool,
+    include_wind_solar_forecast: bool,
+    include_residual_load: bool,
+    include_outages: bool,
+) -> Dict[str, Sensor]:
+    """Ensure the sensors for the requested regressors exist, returning them by name."""
+    specs: List[Tuple] = []
+    if include_load_forecast:
+        specs.append(regressors.LOAD_FORECAST_SENSOR_SPEC)
+    if include_wind_solar_forecast:
+        specs.extend(regressors.WIND_SOLAR_SENSOR_SPECS)
+    if include_residual_load:
+        specs.append(regressors.RESIDUAL_LOAD_SENSOR_SPEC)
+    if include_outages:
+        specs.append(regressors.OUTAGES_SENSOR_SPEC)
+    if not specs:
+        return {}
+    return ensure_sensors(tuple(specs), country_code, country_timezone)
+
+
+def _wind_solar_to_save(
+    green_forecast: pd.DataFrame,
+    ensured_sensors: Dict[str, Sensor],
+    country_code: str,
+    log,
+) -> List[Tuple[Sensor, pd.Series, bool]]:
+    """Pair each reported green column with its sensor (skipping columns not reported)."""
+    triples: List[Tuple[Sensor, pd.Series, bool]] = []
+    for column in regressors.GREEN_COLUMNS:
+        series = regressors.green_column(green_forecast, column)
+        if series is None:
+            log.warning(
+                f"ENTSO-E did not report '{column}' for {country_code}; skipping that sensor."
+            )
+            continue
+        triples.append((ensured_sensors[column], series, True))
+    return triples
+
+
+def _build_residual_load(
+    load_series: pd.Series, green_forecast: pd.DataFrame, log
+) -> pd.Series:
+    """Derive residual load, aligning all inputs to hourly means first."""
+    log.info("Computing residual load (load − wind & solar) ...")
+
+    def to_hourly(series: Optional[pd.Series]) -> pd.Series:
+        if series is None or series.empty:
+            return pd.Series(dtype="float64")
+        return series.resample("1h").mean()
+
+    residual_load = regressors.compute_residual_load(
+        load_forecast=to_hourly(load_series),
+        solar=to_hourly(regressors.green_column(green_forecast, "Solar")),
+        wind_offshore=to_hourly(
+            regressors.green_column(green_forecast, "Wind Offshore")
+        ),
+        wind_onshore=to_hourly(regressors.green_column(green_forecast, "Wind Onshore")),
+    )
+    log.debug("Residual load: \n%s" % residual_load)
+    return residual_load
+
+
+def _save_regressor_series(
+    to_save: List[Tuple[Sensor, pd.Series, bool]],
+    log,
+    entsoe_data_source: Source,
+    country_timezone: str,
+    now: datetime,
+):
+    """Save each regressor series, using the derived data source for derived series."""
+    derived_data_source = None  # created lazily, only if we save derived data
+    for sensor, series, is_entsoe_data in to_save:
+        series = resample_if_needed(series, sensor)
+        if is_entsoe_data:
+            regressor_source = entsoe_data_source
+        else:
+            if derived_data_source is None:
+                derived_data_source = ensure_data_source_for_derived_data()
+            regressor_source = derived_data_source
+        log.info(f"Saving {len(series)} beliefs for Sensor {sensor.name} ...")
+        save_entsoe_series(series, sensor, regressor_source, country_timezone, now)

--- a/flexmeasures_entsoe/prices/regressors.py
+++ b/flexmeasures_entsoe/prices/regressors.py
@@ -1,0 +1,165 @@
+"""
+Extra regressor series that improve day-ahead electricity-price forecasting.
+
+Research on the Dutch (NL) day-ahead market established that ENTSO-E day-ahead
+*fundamentals* dramatically improve price forecasting, especially for hard cases
+(public holidays and the solar-driven midday price collapse):
+
+- **Residual load** (= day-ahead load forecast − day-ahead wind & solar forecast) is
+  the single best regressor. Because the day-ahead *price* is formed against these very
+  forecasts, residual load flattens the spurious holiday-morning price peak and captures
+  the midday collapse.
+- **Generation outages** (day-ahead-known unavailable capacity) are a weaker, but
+  physically relevant, regressor for scarcity.
+
+This module only holds the *pure* helpers (outage aggregation and residual-load
+derivation) and the sensor specifications, so it can be imported and unit-tested without
+a FlexMeasures app or database. The orchestration (querying ENTSO-E and saving beliefs)
+lives in ``day_ahead.py``.
+"""
+
+from datetime import timedelta
+from typing import Optional
+
+import pandas as pd
+
+
+# Machine-readable choices for the CLI and the names of the sensors each regressor
+# writes to. Wind & solar reuse the sensor names already created by the generation
+# import command, so those series are not duplicated.
+LOAD_FORECAST_REGRESSOR = "load-forecast"
+WIND_SOLAR_FORECAST_REGRESSOR = "wind-solar-forecast"
+RESIDUAL_LOAD_REGRESSOR = "residual-load"
+OUTAGES_REGRESSOR = "outages"
+
+# sensor_name, unit, event_resolution, data sourced directly by ENTSO-E (True) or derived (False)
+LOAD_FORECAST_SENSOR_SPEC = ("Day-ahead load forecast", "MW", timedelta(hours=1), True)
+WIND_SOLAR_SENSOR_SPECS = (
+    ("Solar", "MW", timedelta(hours=1), True),
+    ("Wind Onshore", "MW", timedelta(hours=1), True),
+    ("Wind Offshore", "MW", timedelta(hours=1), True),
+)
+RESIDUAL_LOAD_SENSOR_SPEC = ("Residual load", "MW", timedelta(hours=1), False)
+OUTAGES_SENSOR_SPEC = ("Generation outages", "MW", timedelta(hours=1), True)
+
+# The three green columns we subtract from the load forecast to obtain residual load.
+GREEN_COLUMNS = ("Solar", "Wind Offshore", "Wind Onshore")
+
+
+def compute_residual_load(
+    load_forecast: pd.Series,
+    solar: pd.Series,
+    wind_offshore: pd.Series,
+    wind_onshore: pd.Series,
+) -> pd.Series:
+    """Derive residual load from a day-ahead load forecast and green forecasts.
+
+    residual load = load forecast − solar − wind offshore − wind onshore
+
+    All inputs should be (hourly) MW series; they are aligned on their datetime index
+    before subtracting, so missing green components simply do not lower the residual.
+    Residual load is the strongest single regressor for NL day-ahead prices: the price is
+    set against these very forecasts, so residual load tracks the scarcity that drives it
+    (and flattens the spurious holiday-morning peak while capturing the midday collapse).
+    """
+    frame = pd.concat(
+        {
+            "load": load_forecast,
+            "solar": solar,
+            "wind_offshore": wind_offshore,
+            "wind_onshore": wind_onshore,
+        },
+        axis="columns",
+    )
+    residual = (
+        frame["load"]
+        - frame["solar"].fillna(0.0)
+        - frame["wind_offshore"].fillna(0.0)
+        - frame["wind_onshore"].fillna(0.0)
+    )
+    return residual.rename("Residual load")
+
+
+def aggregate_outages_to_hourly_unavailable_mw(
+    outages: pd.DataFrame,
+    from_time: pd.Timestamp,
+    until_time: pd.Timestamp,
+) -> pd.Series:
+    """Aggregate generation-unit outages into an hourly series of total unavailable MW.
+
+    ``outages`` is the DataFrame returned by
+    ``EntsoePandasClient.query_unavailability_of_generation_units``: it is indexed by the
+    outage's publication time (``created_doc_time``) and has (at least) the columns
+    ``nominal_power``, ``start``, ``end`` and ``avail_qty``. Each row describes one
+    available-period of an outage; the unavailable capacity during that period is
+    ``nominal_power − avail_qty`` MW.
+
+    For every target hour in ``[from_time, until_time)`` we sum the unavailable capacity
+    of every outage period that overlaps that hour.
+
+    Knowledge-horizon correctness (IMPORTANT, avoids a look-ahead leak)
+    ------------------------------------------------------------------
+    Day-ahead prices are formed with only the information published *before* the delivery
+    day. We therefore count an outage for a target hour **only if its publication time
+    (``created_doc_time``) is strictly before the start of that hour's delivery day**
+    (local midnight). An outage announced on or after the delivery day was not known when
+    the day-ahead auction cleared, so feeding it into the regressor would leak future
+    information and inflate the apparent forecasting skill. Because a single outage's
+    publication time is compared against each target hour's own delivery day, the same
+    raw outage table can be aggregated once for a multi-day range without leaking.
+
+    Returns an hourly ``pd.Series`` (0.0 where nothing applies) indexed at the start of
+    each hour, in the timezone of ``from_time``.
+    """
+    hours = pd.date_range(
+        start=from_time.floor("h"),
+        end=until_time,
+        freq="1h",
+        inclusive="left",
+    )
+    unavailable_mw = pd.Series(0.0, index=hours, name="Generation outages")
+    if outages is None or outages.empty:
+        return unavailable_mw
+
+    # 'created_doc_time' is the index of the ENTSO-E outages DataFrame.
+    rows = outages.reset_index()
+    for _, row in rows.iterrows():
+        created: pd.Timestamp = row["created_doc_time"]
+        outage_start: pd.Timestamp = row["start"]
+        outage_end: pd.Timestamp = row["end"]
+        nominal_power = row["nominal_power"]
+        avail_qty = row["avail_qty"]
+
+        if pd.isna(nominal_power):
+            # Without a nominal power we cannot quantify the outage.
+            continue
+        if pd.isna(avail_qty):
+            # A void available quantity means the unit is fully unavailable.
+            avail_qty = 0.0
+        unavailable = float(nominal_power) - float(avail_qty)
+        if unavailable <= 0:
+            continue
+
+        for hour_start in hours:
+            delivery_day = hour_start.normalize()  # local midnight of the delivery day
+            if created >= delivery_day:
+                # Not known before the delivery day -> would be a look-ahead leak.
+                continue
+            hour_end = hour_start + pd.Timedelta(hours=1)
+            if outage_start < hour_end and outage_end > hour_start:
+                unavailable_mw[hour_start] += unavailable
+    return unavailable_mw
+
+
+def load_series_from_forecast(load_forecast: pd.DataFrame) -> pd.Series:
+    """Extract the forecasted-load series from ENTSO-E's load-forecast DataFrame."""
+    if "Forecasted Load" in load_forecast.columns:
+        return load_forecast["Forecasted Load"]
+    return load_forecast.iloc[:, 0]
+
+
+def green_column(green_forecast: pd.DataFrame, column: str) -> Optional[pd.Series]:
+    """Return a green-forecast column if ENTSO-E reported it for this country, else None."""
+    if column in green_forecast.columns:
+        return green_forecast[column]
+    return None

--- a/flexmeasures_entsoe/prices/regressors.py
+++ b/flexmeasures_entsoe/prices/regressors.py
@@ -46,6 +46,23 @@ OUTAGES_SENSOR_SPEC = ("Generation outages", "MW", timedelta(hours=1), True)
 GREEN_COLUMNS = ("Solar", "Wind Offshore", "Wind Onshore")
 
 
+# Interconnected neighbours per price country, defined by (day-ahead) interconnector.
+#
+# A €500+/MWh NL scarcity spike is usually a *regional* NW-European event: when Germany,
+# Belgium, Great Britain and the Nordics are tight at the same time, imports into NL dry
+# up. The neighbours' own day-ahead residual-load forecasts therefore measurably improve
+# NL spike and evening-peak price forecasts. When --include-neighbours is set, each
+# selected regressor (except domestic outages) is also fetched and saved for these
+# neighbours, into per-country sensors (e.g. "Residual load (DE_LU)").
+#
+# Countries not listed here (or mapped to an empty list) simply make --include-neighbours
+# a no-op rather than an error.
+# TODO: populate the neighbour sets for price countries other than NL.
+INTERCONNECTED_NEIGHBOURS = {
+    "NL": ["DE_LU", "BE", "GB", "NO_2", "DK_1"],
+}
+
+
 def compute_residual_load(
     load_forecast: pd.Series,
     solar: pd.Series,
@@ -56,26 +73,21 @@ def compute_residual_load(
 
     residual load = load forecast − solar − wind offshore − wind onshore
 
-    All inputs should be (hourly) MW series; they are aligned on their datetime index
-    before subtracting, so missing green components simply do not lower the residual.
+    All inputs should be (hourly) MW series. Each green series is aligned onto the load
+    forecast's index (missing timestamps treated as zero), so residual load keeps the load
+    forecast's (datetime) index even when a green component is missing entirely — which is
+    exactly the NO_2 / DK_1 case, where residual then falls back to the plain load forecast.
     Residual load is the strongest single regressor for NL day-ahead prices: the price is
     set against these very forecasts, so residual load tracks the scarcity that drives it
     (and flattens the spurious holiday-morning peak while capturing the midday collapse).
     """
-    frame = pd.concat(
-        {
-            "load": load_forecast,
-            "solar": solar,
-            "wind_offshore": wind_offshore,
-            "wind_onshore": wind_onshore,
-        },
-        axis="columns",
-    )
+    index = load_forecast.index
+
+    def aligned(green: pd.Series) -> pd.Series:
+        return green.reindex(index).fillna(0.0)
+
     residual = (
-        frame["load"]
-        - frame["solar"].fillna(0.0)
-        - frame["wind_offshore"].fillna(0.0)
-        - frame["wind_onshore"].fillna(0.0)
+        load_forecast - aligned(solar) - aligned(wind_offshore) - aligned(wind_onshore)
     )
     return residual.rename("Residual load")
 
@@ -158,8 +170,15 @@ def load_series_from_forecast(load_forecast: pd.DataFrame) -> pd.Series:
     return load_forecast.iloc[:, 0]
 
 
-def green_column(green_forecast: pd.DataFrame, column: str) -> Optional[pd.Series]:
-    """Return a green-forecast column if ENTSO-E reported it for this country, else None."""
-    if column in green_forecast.columns:
-        return green_forecast[column]
-    return None
+def green_column(
+    green_forecast: Optional[pd.DataFrame], column: str
+) -> Optional[pd.Series]:
+    """Return a green-forecast column if ENTSO-E reported it for this country, else None.
+
+    ``green_forecast`` may be None when no wind & solar forecast is published at all (e.g.
+    for NO_2 / DK_1); in that case every column is simply treated as missing, so residual
+    load falls back to the plain load forecast instead of crashing.
+    """
+    if green_forecast is None or column not in green_forecast.columns:
+        return None
+    return green_forecast[column]

--- a/flexmeasures_entsoe/prices/regressors.py
+++ b/flexmeasures_entsoe/prices/regressors.py
@@ -12,16 +12,17 @@ Research on the Dutch (NL) day-ahead market established that ENTSO-E day-ahead
 - **Generation outages** (day-ahead-known unavailable capacity) are a weaker, but
   physically relevant, regressor for scarcity.
 
-This module only holds the *pure* helpers (outage aggregation and residual-load
-derivation) and the sensor specifications, so it can be imported and unit-tested without
-a FlexMeasures app or database. The orchestration (querying ENTSO-E and saving beliefs)
-lives in ``day_ahead.py``.
+This module only holds the *pure* helpers (outage aggregation, residual-load derivation,
+neighbour lookup and timezone lookup) and the sensor specifications, so it can be imported
+and unit-tested without a FlexMeasures app or database. The orchestration (querying
+ENTSO-E and saving beliefs) lives in ``regressors_import.py``.
 """
 
 from datetime import timedelta
-from typing import Optional
+from typing import List, Optional
 
 import pandas as pd
+from entsoe.mappings import NEIGHBOURS, lookup_area
 
 
 # Machine-readable choices for the CLI and the names of the sensors each regressor
@@ -46,21 +47,37 @@ OUTAGES_SENSOR_SPEC = ("Generation outages", "MW", timedelta(hours=1), True)
 GREEN_COLUMNS = ("Solar", "Wind Offshore", "Wind Onshore")
 
 
-# Interconnected neighbours per price country, defined by (day-ahead) interconnector.
-#
-# A €500+/MWh NL scarcity spike is usually a *regional* NW-European event: when Germany,
-# Belgium, Great Britain and the Nordics are tight at the same time, imports into NL dry
-# up. The neighbours' own day-ahead residual-load forecasts therefore measurably improve
-# NL spike and evening-peak price forecasts. When --include-neighbours is set, each
-# selected regressor (except domestic outages) is also fetched and saved for these
-# neighbours, into per-country sensors (e.g. "Residual load (DE_LU)").
-#
-# Countries not listed here (or mapped to an empty list) simply make --include-neighbours
-# a no-op rather than an error.
-# TODO: populate the neighbour sets for price countries other than NL.
-INTERCONNECTED_NEIGHBOURS = {
-    "NL": ["DE_LU", "BE", "GB", "NO_2", "DK_1"],
-}
+def neighbours_for(country_code: str) -> List[str]:
+    """Interconnected neighbours of a country/bidding-zone, per ENTSO-E's own mapping.
+
+    A €500+/MWh NL scarcity spike is usually a *regional* NW-European event: when Germany,
+    Belgium, Great Britain and the Nordics are tight at the same time, imports into NL dry
+    up. The neighbours' own day-ahead residual-load forecasts therefore measurably improve
+    NL spike and evening-peak price forecasts.
+
+    The neighbour set is taken directly from ``entsoe.mappings.NEIGHBOURS`` (a maintained
+    upstream dict of area -> interconnected areas), rather than hand-maintained here, so it
+    covers every country and tracks interconnection changes as the library is updated. For
+    NL this yields e.g. BE, DE_LU, DE_AT_LU, GB, NO_2 and DK_1. The entries are already the
+    (bidding-zone) codes that the ``query_*`` functions accept via ``lookup_area``; a code
+    with no day-ahead data (e.g. the deprecated DE_AT_LU zone) is simply skipped at import
+    time by the lenient neighbour fetch. Unknown countries return an empty list, so the
+    ``--include-neighbours`` flag is a harmless no-op for them rather than an error.
+    """
+    return list(NEIGHBOURS.get(country_code, []))
+
+
+def timezone_for(country_code: str) -> Optional[str]:
+    """Return the IANA timezone of a country/bidding-zone code, per entsoe-py's Area enum.
+
+    Used so each country's sensors carry their *own* timezone as metadata (e.g. NL/DE/BE ->
+    Europe/…, GB -> Europe/London, NO_2 -> Europe/Oslo, DK_1 -> Europe/Copenhagen). Returns
+    None if the code is not a known ENTSO-E area.
+    """
+    try:
+        return lookup_area(country_code).tz
+    except (KeyError, ValueError):
+        return None
 
 
 def compute_residual_load(

--- a/flexmeasures_entsoe/prices/regressors_import.py
+++ b/flexmeasures_entsoe/prices/regressors_import.py
@@ -91,7 +91,7 @@ def collect_and_save_regressors(
     neighbours = regressors.neighbours_for(country_code)
     if not neighbours:
         log.warning(
-            f"ENTSO-E lists no interconnected neighbours for {country_code}; "
+            f"ENTSO-E lists no interconnected neighbours for {country_code}, so "
             "--include-neighbours has no effect."
         )
     for neighbour in neighbours:
@@ -152,7 +152,9 @@ def _collect_ensure_and_save(
         outages_sensor=outages_sensor,
     )
     if not dryrun:
-        _save_results(results, country_code, timezone, log, entsoe_data_source, now)
+        _save_results(
+            results, country_code, timezone, log, entsoe_data_source, now, strict=strict
+        )
 
 
 def _collect_country_regressors(
@@ -218,14 +220,14 @@ def _collect_country_regressors(
             series = regressors.green_column(green_forecast, column)
             if series is None:
                 log.warning(
-                    f"ENTSO-E did not report '{column}' for {country_code}; skipping that sensor."
+                    f"ENTSO-E did not report '{column}' for {country_code}, skipping that sensor."
                 )
                 continue
             results.append((_GREEN_SPEC_BY_NAME[column], None, series, True))
     if include_residual_load:
         if load_series is None:
             log.warning(
-                f"No load forecast for {country_code}; cannot derive residual load. Skipping."
+                f"No load forecast for {country_code}, cannot derive residual load. Skipping."
             )
         else:
             residual_load = _build_residual_load(load_series, green_forecast, log)
@@ -260,8 +262,15 @@ def _save_results(
     log,
     entsoe_data_source: Source,
     now,
+    strict: bool = True,
 ):
-    """Ensure the needed sensors (once) and save each regressor series to its sensor."""
+    """Ensure the needed sensors (once) and save each regressor series to its sensor.
+
+    With ``strict=False`` (used for neighbours), a series whose timestamps cannot be
+    aligned to its sensor's resolution is skipped with a warning instead of aborting
+    the remaining series and zones, extending the lenient policy of
+    :func:`_query_series` to the saving step.
+    """
     if not results:
         return
 
@@ -273,7 +282,15 @@ def _save_results(
     derived_data_source = None  # created lazily, only if we save derived data
     for spec, override, series, is_entsoe_data in results:
         sensor = override if override is not None else ensured[spec[0]]
-        series = resample_if_needed(series, sensor)
+        try:
+            series = resample_if_needed(series, sensor)
+        except ValueError as e:
+            if strict:
+                raise
+            log.warning(
+                f"Could not align {sensor.name} data for {country_code} ({e}), skipping."
+            )
+            continue
         if is_entsoe_data:
             source = entsoe_data_source
         else:
@@ -294,15 +311,17 @@ def _query_series(client_call, strict: bool, log, description: str):
     """
     try:
         data = client_call()
-    except Exception as e:  # noqa: B902 - any ENTSO-E failure for a neighbour is non-fatal
+    except (
+        Exception
+    ) as e:  # noqa: B902 - any ENTSO-E failure for a neighbour is non-fatal
         if strict:
             raise
-        log.warning(f"Could not get {description} ({e}); skipping.")
+        log.warning(f"Could not get {description} ({e}), skipping.")
         return None
     if data is None or (hasattr(data, "empty") and data.empty):
         if strict:
             abort_if_data_empty(data)  # raises click.Abort
-        log.warning(f"No {description} available; skipping.")
+        log.warning(f"No {description} available, skipping.")
         return None
     return data
 

--- a/flexmeasures_entsoe/prices/regressors_import.py
+++ b/flexmeasures_entsoe/prices/regressors_import.py
@@ -1,0 +1,334 @@
+"""
+Orchestration for importing extra price-forecasting regressors from ENTSO-E.
+
+This module does the FlexMeasures/ENTSO-E work (querying the client, ensuring sensors and
+saving beliefs) and is kept separate from the pure helpers in ``regressors.py`` (which stay
+importable without a FlexMeasures app or database). ``day_ahead.py`` only wires the CLI and
+calls :func:`collect_and_save_regressors`.
+
+Regressor sensors are identified by their *asset*, not by their name: a country's series
+are saved to plainly-named sensors (``Residual load``, ``Day-ahead load forecast``, ...)
+that live on that country's own transmission-zone asset, each carrying that country's own
+timezone. So NL's ``Residual load`` and DE_LU's ``Residual load`` are distinct sensors on
+distinct assets.
+"""
+
+from typing import List, Optional, Tuple
+
+import pandas as pd
+from flexmeasures import Sensor, Source
+
+from . import regressors
+from ..utils import (
+    ensure_data_source_for_derived_data,
+    ensure_sensors,
+    abort_if_data_empty,
+    save_entsoe_series,
+    resample_if_needed,
+)
+
+# One regressor result: (base sensor spec, optional sensor override, the series, whether
+# the data comes straight from ENTSO-E (True) or is derived by us (False)).
+RegressorResult = Tuple[Tuple, Optional[Sensor], pd.Series, bool]
+
+# Map a green-forecast column to the sensor spec it is saved into.
+_GREEN_SPEC_BY_NAME = {spec[0]: spec for spec in regressors.WIND_SOLAR_SENSOR_SPECS}
+
+
+def collect_and_save_regressors(
+    client,
+    log,
+    dryrun: bool,
+    country_code: str,
+    country_timezone: str,
+    from_time: pd.Timestamp,
+    until_time: pd.Timestamp,
+    now,
+    entsoe_data_source: Source,
+    include_load_forecast: bool,
+    include_wind_solar_forecast: bool,
+    include_residual_load: bool,
+    include_outages: bool,
+    include_neighbours: bool = False,
+    load_forecast_sensor: Optional[Sensor] = None,
+    residual_load_sensor: Optional[Sensor] = None,
+    outages_sensor: Optional[Sensor] = None,
+):
+    """Query and save the requested regressor series for the price country (and neighbours).
+
+    Data is only fetched from ENTSO-E when needed: residual load implies fetching the load
+    and wind & solar forecasts, even when those are not saved themselves.
+
+    With ``include_neighbours``, the same regressors (except domestic outages) are also
+    collected for the price country's interconnected neighbours (from
+    ``entsoe.mappings.NEIGHBOURS``). Missing neighbour data is skipped gracefully rather
+    than aborting the import, and residual load then falls back to the plain load forecast.
+    """
+    # The price country: strict (abort on empty data), may use sensor overrides & outages.
+    _collect_ensure_and_save(
+        client=client,
+        log=log,
+        dryrun=dryrun,
+        country_code=country_code,
+        timezone=country_timezone,
+        from_time=from_time,
+        until_time=until_time,
+        now=now,
+        entsoe_data_source=entsoe_data_source,
+        include_load_forecast=include_load_forecast,
+        include_wind_solar_forecast=include_wind_solar_forecast,
+        include_residual_load=include_residual_load,
+        include_outages=include_outages,
+        strict=True,
+        load_forecast_sensor=load_forecast_sensor,
+        residual_load_sensor=residual_load_sensor,
+        outages_sensor=outages_sensor,
+    )
+
+    if not include_neighbours:
+        return
+
+    neighbours = regressors.neighbours_for(country_code)
+    if not neighbours:
+        log.warning(
+            f"ENTSO-E lists no interconnected neighbours for {country_code}; "
+            "--include-neighbours has no effect."
+        )
+    for neighbour in neighbours:
+        log.info(f"Collecting regressors for neighbour {neighbour} ...")
+        # Neighbours: lenient (skip missing data), no outages, no sensor overrides, and
+        # each on its own transmission-zone asset with its own timezone.
+        _collect_ensure_and_save(
+            client=client,
+            log=log,
+            dryrun=dryrun,
+            country_code=neighbour,
+            timezone=regressors.timezone_for(neighbour) or country_timezone,
+            from_time=from_time,
+            until_time=until_time,
+            now=now,
+            entsoe_data_source=entsoe_data_source,
+            include_load_forecast=include_load_forecast,
+            include_wind_solar_forecast=include_wind_solar_forecast,
+            include_residual_load=include_residual_load,
+            include_outages=False,  # outages stay domestic-only
+            strict=False,
+        )
+
+
+def _collect_ensure_and_save(
+    client,
+    log,
+    dryrun: bool,
+    country_code: str,
+    timezone: str,
+    from_time: pd.Timestamp,
+    until_time: pd.Timestamp,
+    now,
+    entsoe_data_source: Source,
+    include_load_forecast: bool,
+    include_wind_solar_forecast: bool,
+    include_residual_load: bool,
+    include_outages: bool,
+    strict: bool,
+    load_forecast_sensor: Optional[Sensor] = None,
+    residual_load_sensor: Optional[Sensor] = None,
+    outages_sensor: Optional[Sensor] = None,
+):
+    """Collect one country's regressor series, then (unless dryrun) ensure sensors & save."""
+    results = _collect_country_regressors(
+        client=client,
+        log=log,
+        country_code=country_code,
+        from_time=from_time,
+        until_time=until_time,
+        include_load_forecast=include_load_forecast,
+        include_wind_solar_forecast=include_wind_solar_forecast,
+        include_residual_load=include_residual_load,
+        include_outages=include_outages,
+        strict=strict,
+        load_forecast_sensor=load_forecast_sensor,
+        residual_load_sensor=residual_load_sensor,
+        outages_sensor=outages_sensor,
+    )
+    if not dryrun:
+        _save_results(results, country_code, timezone, log, entsoe_data_source, now)
+
+
+def _collect_country_regressors(
+    client,
+    log,
+    country_code: str,
+    from_time: pd.Timestamp,
+    until_time: pd.Timestamp,
+    include_load_forecast: bool,
+    include_wind_solar_forecast: bool,
+    include_residual_load: bool,
+    include_outages: bool,
+    strict: bool = True,
+    load_forecast_sensor: Optional[Sensor] = None,
+    residual_load_sensor: Optional[Sensor] = None,
+    outages_sensor: Optional[Sensor] = None,
+) -> List[RegressorResult]:
+    """Fetch one country's data and pair each resulting series with its sensor spec.
+
+    Returns a list of :data:`RegressorResult`. With ``strict=False`` (used for neighbours),
+    missing data is skipped with a warning instead of aborting the whole import; sensors are
+    only referenced for series that actually have data (so dead zones create no clutter).
+    """
+    # Query ENTSO-E only for what we need (residual load implies both forecasts).
+    load_series = None
+    green_forecast = None
+    if include_load_forecast or include_residual_load:
+        load_forecast = _query_series(
+            lambda: client.query_load_forecast(
+                country_code, start=from_time, end=until_time
+            ),
+            strict=strict,
+            log=log,
+            description=f"day-ahead load forecast for {country_code}",
+        )
+        if load_forecast is not None:
+            load_series = regressors.load_series_from_forecast(load_forecast)
+            log.debug("Load forecast: \n%s" % load_series)
+    if include_wind_solar_forecast or include_residual_load:
+        green_forecast = _query_series(
+            lambda: client.query_wind_and_solar_forecast(
+                country_code, start=from_time, end=until_time, psr_type=None
+            ),
+            strict=strict,
+            log=log,
+            description=f"day-ahead wind & solar forecast for {country_code}",
+        )
+        if green_forecast is not None:
+            log.debug("Wind & solar forecast: \n%s" % green_forecast)
+
+    results: List[RegressorResult] = []
+    if include_load_forecast and load_series is not None:
+        results.append(
+            (
+                regressors.LOAD_FORECAST_SENSOR_SPEC,
+                load_forecast_sensor,
+                load_series,
+                True,
+            )
+        )
+    if include_wind_solar_forecast and green_forecast is not None:
+        for column in regressors.GREEN_COLUMNS:
+            series = regressors.green_column(green_forecast, column)
+            if series is None:
+                log.warning(
+                    f"ENTSO-E did not report '{column}' for {country_code}; skipping that sensor."
+                )
+                continue
+            results.append((_GREEN_SPEC_BY_NAME[column], None, series, True))
+    if include_residual_load:
+        if load_series is None:
+            log.warning(
+                f"No load forecast for {country_code}; cannot derive residual load. Skipping."
+            )
+        else:
+            residual_load = _build_residual_load(load_series, green_forecast, log)
+            results.append(
+                (
+                    regressors.RESIDUAL_LOAD_SENSOR_SPEC,
+                    residual_load_sensor,
+                    residual_load,
+                    False,
+                )
+            )
+    if include_outages:
+        log.info("Getting generation outages (unavailable capacity) ...")
+        outages = client.query_unavailability_of_generation_units(
+            country_code, start=from_time, end=until_time
+        )
+        # Note: outages may legitimately be empty (no announced outages), so we do not abort.
+        unavailable_mw = regressors.aggregate_outages_to_hourly_unavailable_mw(
+            outages, from_time, until_time
+        )
+        log.debug("Hourly unavailable capacity (MW): \n%s" % unavailable_mw)
+        results.append(
+            (regressors.OUTAGES_SENSOR_SPEC, outages_sensor, unavailable_mw, True)
+        )
+    return results
+
+
+def _save_results(
+    results: List[RegressorResult],
+    country_code: str,
+    timezone: str,
+    log,
+    entsoe_data_source: Source,
+    now,
+):
+    """Ensure the needed sensors (once) and save each regressor series to its sensor."""
+    if not results:
+        return
+
+    # Ensure sensors for results that do not carry an explicit override, in one call, so the
+    # country's transmission-zone asset is created once and only for series we actually have.
+    specs = tuple(spec for spec, override, _, _ in results if override is None)
+    ensured = ensure_sensors(specs, country_code, timezone) if specs else {}
+
+    derived_data_source = None  # created lazily, only if we save derived data
+    for spec, override, series, is_entsoe_data in results:
+        sensor = override if override is not None else ensured[spec[0]]
+        series = resample_if_needed(series, sensor)
+        if is_entsoe_data:
+            source = entsoe_data_source
+        else:
+            if derived_data_source is None:
+                derived_data_source = ensure_data_source_for_derived_data()
+            source = derived_data_source
+        log.info(f"Saving {len(series)} beliefs for Sensor {sensor.name} ...")
+        save_entsoe_series(series, sensor, source, timezone, now)
+
+
+def _query_series(client_call, strict: bool, log, description: str):
+    """Run an ENTSO-E query, returning None on missing data when not strict.
+
+    In strict mode (price country) an empty result aborts, matching the price import. In
+    lenient mode (neighbours) both a raised exception (e.g. entsoe's NoMatchingDataError)
+    and an empty result become a warning + None, so one missing neighbour series never
+    crashes the import.
+    """
+    try:
+        data = client_call()
+    except Exception as e:  # noqa: B902 - any ENTSO-E failure for a neighbour is non-fatal
+        if strict:
+            raise
+        log.warning(f"Could not get {description} ({e}); skipping.")
+        return None
+    if data is None or (hasattr(data, "empty") and data.empty):
+        if strict:
+            abort_if_data_empty(data)  # raises click.Abort
+        log.warning(f"No {description} available; skipping.")
+        return None
+    return data
+
+
+def _build_residual_load(
+    load_series: pd.Series, green_forecast: Optional[pd.DataFrame], log
+) -> pd.Series:
+    """Derive residual load, aligning all inputs to hourly means first.
+
+    ``green_forecast`` may be None (no wind & solar published for this country), in which
+    case residual load falls back to the plain load forecast.
+    """
+    log.info("Computing residual load (load − wind & solar) ...")
+
+    def to_hourly(series: Optional[pd.Series]) -> pd.Series:
+        if series is None or series.empty:
+            return pd.Series(dtype="float64")
+        return series.resample("1h").mean()
+
+    residual_load = regressors.compute_residual_load(
+        load_forecast=to_hourly(load_series),
+        solar=to_hourly(regressors.green_column(green_forecast, "Solar")),
+        wind_offshore=to_hourly(
+            regressors.green_column(green_forecast, "Wind Offshore")
+        ),
+        wind_onshore=to_hourly(regressors.green_column(green_forecast, "Wind Onshore")),
+    )
+    log.debug("Residual load: \n%s" % residual_load)
+    return residual_load

--- a/flexmeasures_entsoe/utils.py
+++ b/flexmeasures_entsoe/utils.py
@@ -1,9 +1,9 @@
 from typing import Dict, Optional, Tuple, Union
 from datetime import datetime, timedelta
-from logging import Logger
+from logging import Logger, getLogger
 
 from entsoe import EntsoePandasClient
-from flask import current_app
+from flask import current_app, has_app_context
 from packaging import version
 from pandas.tseries.frequencies import to_offset
 import pandas as pd
@@ -304,12 +304,28 @@ def parse_from_and_to_dates(
 
 
 def resample_if_needed(s: pd.Series, sensor: Sensor) -> pd.Series:
-    inferred_frequency = pd.infer_freq(s.index)
-    if inferred_frequency is None:
-        raise ValueError(
-            "Data has no discernible frequency from which to derive an event resolution."
+    try:
+        inferred_frequency = pd.infer_freq(s.index)
+    except ValueError:  # pd.infer_freq needs at least 3 timestamps
+        inferred_frequency = None
+    if inferred_frequency is not None:
+        inferred_resolution = pd.to_timedelta(to_offset(inferred_frequency))
+    else:
+        # Gaps in the data (e.g. hours missing from a neighbour zone's series)
+        # defeat pd.infer_freq. The most common spacing between consecutive
+        # timestamps still identifies the resolution in that case.
+        spacings = s.index.to_series().diff().dropna()
+        if spacings.empty:
+            raise ValueError(
+                "Data has no discernible frequency from which to derive an event resolution."
+            )
+        inferred_resolution = spacings.mode().iloc[0]
+        logger = current_app.logger if has_app_context() else getLogger(__name__)
+        logger.warning(
+            f"Data for {sensor.name} has an irregular index (e.g. gaps), "
+            f"assuming an event resolution of {inferred_resolution} "
+            "(the most common timestamp spacing)."
         )
-    inferred_resolution = pd.to_timedelta(to_offset(inferred_frequency))
     target_resolution = sensor.event_resolution
     if inferred_resolution == target_resolution:
         return s
@@ -324,7 +340,8 @@ def resample_if_needed(s: pd.Series, sensor: Sensor) -> pd.Series:
         s = s.reindex(index).pad()
     elif inferred_resolution < target_resolution:
         current_app.logger.debug(f"Downsampling data for {sensor.name} ...")
-        s = s.resample(target_resolution).mean()
+        # Gaps in the data leave empty (NaN) buckets, which are not saved as beliefs.
+        s = s.resample(target_resolution).mean().dropna()
     current_app.logger.debug(f"Resampled data for {sensor.name}: \n%s" % s)
     return s
 

--- a/flexmeasures_entsoe/utils.py
+++ b/flexmeasures_entsoe/utils.py
@@ -68,7 +68,7 @@ def ensure_transmission_zone_asset(country_code: str) -> Asset:
 
 
 def ensure_sensors(
-    sensor_specifications: Tuple[Tuple],
+    sensor_specifications: Tuple[Tuple, ...],
     country_code: str,
     timezone: str,
 ) -> Dict[str, Sensor]:
@@ -209,7 +209,6 @@ def parse_from_and_to_dates_default_yesterday(
 
 def resample_if_needed(s: pd.Series, sensor: Sensor) -> pd.Series:
     inferred_frequency = pd.infer_freq(s.index)
-    breakpoint()
     if inferred_frequency is None:
         raise ValueError(
             "Data has no discernible frequency from which to derive an event resolution."

--- a/flexmeasures_entsoe/utils.py
+++ b/flexmeasures_entsoe/utils.py
@@ -209,6 +209,7 @@ def parse_from_and_to_dates_default_yesterday(
 
 def resample_if_needed(s: pd.Series, sensor: Sensor) -> pd.Series:
     inferred_frequency = pd.infer_freq(s.index)
+    breakpoint()
     if inferred_frequency is None:
         raise ValueError(
             "Data has no discernible frequency from which to derive an event resolution."

--- a/tests/test_neighbours.py
+++ b/tests/test_neighbours.py
@@ -1,0 +1,197 @@
+"""
+Tests for the neighbour-country regressor collection.
+
+These exercise the orchestration in ``prices/day_ahead.py`` with a *mocked* ENTSO-E
+client and a stubbed ``ensure_sensors`` (so no live API and no database are touched). We
+focus on the graceful handling of neighbours that publish no wind & solar forecast (e.g.
+NO_2 / DK_1): residual load must fall back to the plain load forecast instead of crashing.
+
+``flexmeasures`` must be importable for these (the package __init__ pulls it in); if it is
+not installed, the whole module is skipped.
+"""
+
+import pandas as pd
+import pytest
+
+pytest.importorskip("flexmeasures")
+
+from flexmeasures_entsoe.prices import day_ahead  # noqa: E402
+
+TZ = "Europe/Amsterdam"
+FROM_TIME = pd.Timestamp("2025-06-02 00:00", tz=TZ)
+UNTIL_TIME = pd.Timestamp("2025-06-03 00:00", tz=TZ)
+HOURLY = pd.date_range(FROM_TIME, UNTIL_TIME, freq="1h", inclusive="left", tz=TZ)
+
+
+class FakeSensor:
+    def __init__(self, name):
+        self.name = name
+
+    def __repr__(self):
+        return f"<FakeSensor {self.name}>"
+
+
+class FakeLog:
+    def __init__(self):
+        self.warnings = []
+
+    def info(self, *args):
+        pass
+
+    def debug(self, *args):
+        pass
+
+    def warning(self, msg, *args):
+        self.warnings.append(msg)
+
+
+class NoData(Exception):
+    """Stand-in for entsoe.exceptions.NoMatchingDataError."""
+
+
+class FakeClient:
+    """Configurable fake ENTSO-E client.
+
+    wind_solar_mode: 'ok' | 'raise' | 'empty' | 'partial'
+    """
+
+    def __init__(self, wind_solar_mode="ok", load_mode="ok"):
+        self.wind_solar_mode = wind_solar_mode
+        self.load_mode = load_mode
+
+    def query_load_forecast(self, country_code, start, end):
+        if self.load_mode == "raise":
+            raise NoData("no load forecast")
+        if self.load_mode == "empty":
+            return pd.DataFrame({"Forecasted Load": []})
+        return pd.DataFrame({"Forecasted Load": 12000.0}, index=HOURLY)
+
+    def query_wind_and_solar_forecast(self, country_code, start, end, psr_type=None):
+        if self.wind_solar_mode == "raise":
+            raise NoData("no wind & solar forecast")
+        if self.wind_solar_mode == "empty":
+            return pd.DataFrame()
+        if self.wind_solar_mode == "partial":
+            return pd.DataFrame({"Solar": 2000.0}, index=HOURLY)
+        return pd.DataFrame(
+            {"Solar": 2000.0, "Wind Onshore": 1000.0, "Wind Offshore": 500.0},
+            index=HOURLY,
+        )
+
+
+@pytest.fixture
+def stub_ensure_sensors(monkeypatch):
+    """Return sensors named exactly as requested (suffixed), without touching the DB."""
+
+    def _fake_ensure(specs, country_code, timezone):
+        return {spec[0]: FakeSensor(spec[0]) for spec in specs}
+
+    monkeypatch.setattr(day_ahead, "ensure_sensors", _fake_ensure)
+
+
+def _collect(client, **kwargs):
+    log = FakeLog()
+    defaults = dict(
+        client=client,
+        log=log,
+        data_country_code="NO_2",
+        sensor_timezone=TZ,
+        from_time=FROM_TIME,
+        until_time=UNTIL_TIME,
+        include_load_forecast=True,
+        include_wind_solar_forecast=True,
+        include_residual_load=True,
+        include_outages=False,
+        suffix=" (NO_2)",
+        strict=False,
+    )
+    defaults.update(kwargs)
+    triples = day_ahead._collect_country_regressors(**defaults)
+    return triples, log
+
+
+def _by_sensor_name(triples):
+    return {sensor.name: series for sensor, series, _ in triples}
+
+
+@pytest.mark.parametrize("wind_solar_mode", ["raise", "empty"])
+def test_neighbour_without_wind_solar_falls_back_to_load(
+    stub_ensure_sensors, wind_solar_mode
+):
+    """A neighbour that publishes no wind & solar must not crash; residual == load."""
+    client = FakeClient(wind_solar_mode=wind_solar_mode)
+    triples, log = _collect(client)
+
+    saved = _by_sensor_name(triples)
+    # Load forecast is still saved.
+    assert "Day-ahead load forecast (NO_2)" in saved
+    # No wind/solar sensors were produced.
+    assert not any(name.startswith(("Solar", "Wind")) for name in saved)
+    # Residual load exists and equals the load forecast (green fell back to zero).
+    assert "Residual load (NO_2)" in saved
+    residual = saved["Residual load (NO_2)"]
+    assert residual.to_numpy() == pytest.approx([12000.0] * len(HOURLY))
+    # A warning was logged about the missing wind & solar data.
+    assert any("wind & solar" in w for w in log.warnings)
+
+
+def test_neighbour_partial_wind_solar_used_for_residual(stub_ensure_sensors):
+    """If only Solar is published, residual subtracts just Solar (missing wind = 0)."""
+    client = FakeClient(wind_solar_mode="partial")
+    triples, _ = _collect(client)
+
+    saved = _by_sensor_name(triples)
+    # Only the Solar sensor is produced (wind columns absent).
+    assert "Solar (NO_2)" in saved
+    assert "Wind Onshore (NO_2)" not in saved
+    assert "Wind Offshore (NO_2)" not in saved
+    # Residual = 12000 - 2000 = 10000.
+    residual = saved["Residual load (NO_2)"]
+    assert residual.to_numpy() == pytest.approx([10000.0] * len(HOURLY))
+
+
+def test_neighbour_missing_load_skips_residual(stub_ensure_sensors):
+    """Without a load forecast we cannot derive residual load, but must not crash."""
+    client = FakeClient(load_mode="raise", wind_solar_mode="ok")
+    triples, log = _collect(client)
+
+    saved = _by_sensor_name(triples)
+    assert "Day-ahead load forecast (NO_2)" not in saved
+    assert "Residual load (NO_2)" not in saved
+    # Wind & solar are still saved (they don't depend on load).
+    assert "Solar (NO_2)" in saved
+    assert any("cannot derive residual load" in w for w in log.warnings)
+
+
+def test_strict_mode_aborts_on_empty_price_country_data(stub_ensure_sensors):
+    """For the price country (strict), empty ENTSO-E data aborts, as the price import does."""
+    import click
+
+    client = FakeClient(load_mode="empty")
+    with pytest.raises(click.Abort):
+        _collect(
+            client,
+            data_country_code="NL",
+            suffix="",
+            strict=True,
+            include_wind_solar_forecast=False,
+            include_residual_load=False,
+        )
+
+
+def test_full_neighbour_data_produces_all_sensors(stub_ensure_sensors):
+    """With complete data a neighbour yields load, three green, and residual sensors."""
+    client = FakeClient(wind_solar_mode="ok")
+    triples, _ = _collect(client)
+
+    names = set(_by_sensor_name(triples))
+    assert names == {
+        "Day-ahead load forecast (NO_2)",
+        "Solar (NO_2)",
+        "Wind Onshore (NO_2)",
+        "Wind Offshore (NO_2)",
+        "Residual load (NO_2)",
+    }
+    # Residual = 12000 - 2000 - 1000 - 500 = 8500.
+    residual = _by_sensor_name(triples)["Residual load (NO_2)"]
+    assert residual.to_numpy() == pytest.approx([8500.0] * len(HOURLY))

--- a/tests/test_neighbours.py
+++ b/tests/test_neighbours.py
@@ -28,8 +28,9 @@ HOURLY = pd.date_range(FROM_TIME, UNTIL_TIME, freq="1h", inclusive="left", tz=TZ
 
 
 class FakeSensor:
-    def __init__(self, name):
+    def __init__(self, name, event_resolution=None):
         self.name = name
+        self.event_resolution = event_resolution
 
     def __repr__(self):
         return f"<FakeSensor {self.name}>"
@@ -246,3 +247,97 @@ def test_collect_and_save_uses_each_country_own_timezone_and_base_names(monkeypa
 
     # Residual load is saved from the derived source, with the country's own timezone.
     assert ("Residual load", "Europe/London", "DERIVED") in save_calls
+
+
+# ---------------------------------------------------------------------------
+# resample_if_needed and _save_results: irregular (gappy) neighbour data
+# ---------------------------------------------------------------------------
+
+
+def test_resample_if_needed_tolerates_gaps():
+    """Hourly data with missing hours (no inferable frequency) must survive as-is.
+
+    Neighbour zones (e.g. DK_1) can return series with holes, for which
+    ``pd.infer_freq`` finds no frequency; the most common timestamp spacing
+    still identifies the resolution.
+    """
+    from datetime import timedelta
+
+    from flexmeasures_entsoe.utils import resample_if_needed
+
+    gappy_index = HOURLY.delete([3, 4, 10])  # knock holes into the hourly grid
+    series = pd.Series(12000.0, index=gappy_index)
+    sensor = FakeSensor("Day-ahead load forecast", event_resolution=timedelta(hours=1))
+
+    result = resample_if_needed(series, sensor)
+
+    assert result.equals(series)
+
+
+def test_resample_if_needed_still_raises_without_any_spacing():
+    """A single timestamp offers no spacing at all, so the clear error remains."""
+    from datetime import timedelta
+
+    from flexmeasures_entsoe.utils import resample_if_needed
+
+    series = pd.Series([12000.0], index=HOURLY[:1])
+    sensor = FakeSensor("Day-ahead load forecast", event_resolution=timedelta(hours=1))
+
+    with pytest.raises(ValueError, match="no discernible frequency"):
+        resample_if_needed(series, sensor)
+
+
+def _run_save_results_with_unalignable_series(monkeypatch, strict):
+    """Prepare _save_results with one unalignable series among good ones."""
+    saved = []
+    log = FakeLog()
+
+    monkeypatch.setattr(
+        regressors_import,
+        "ensure_sensors",
+        lambda specs, country_code, timezone: {s[0]: FakeSensor(s[0]) for s in specs},
+    )
+    monkeypatch.setattr(
+        regressors_import,
+        "save_entsoe_series",
+        lambda series, sensor, source, timezone, now: saved.append(sensor.name),
+    )
+
+    def picky_resample(series, sensor):
+        if sensor.name == "Day-ahead load forecast":
+            raise ValueError("no discernible frequency")
+        return series
+
+    monkeypatch.setattr(regressors_import, "resample_if_needed", picky_resample)
+
+    good = pd.Series(1.0, index=HOURLY)
+    results = [
+        (("Day-ahead load forecast", "MW", None, True), None, good, True),
+        (("Residual load", "MW", None, True), None, good, True),
+    ]
+
+    def run():
+        regressors_import._save_results(
+            results, "DK_1", "Europe/Copenhagen", log, "ENTSOE", None, strict=strict
+        )
+
+    return run, saved, log
+
+
+def test_save_results_lenient_skips_unalignable_series(monkeypatch):
+    """In lenient (neighbour) mode, one bad series is skipped; the rest still save."""
+    run, saved, log = _run_save_results_with_unalignable_series(
+        monkeypatch, strict=False
+    )
+    run()
+    assert saved == ["Residual load"]
+    assert any("skipping" in w for w in log.warnings)
+
+
+def test_save_results_strict_raises_on_unalignable_series(monkeypatch):
+    """In strict (price country) mode, an unalignable series still aborts."""
+    run, _saved, _log = _run_save_results_with_unalignable_series(
+        monkeypatch, strict=True
+    )
+    with pytest.raises(ValueError):
+        run()

--- a/tests/test_neighbours.py
+++ b/tests/test_neighbours.py
@@ -1,10 +1,14 @@
 """
-Tests for the neighbour-country regressor collection.
+Tests for the neighbour-country regressor collection and saving.
 
-These exercise the orchestration in ``prices/day_ahead.py`` with a *mocked* ENTSO-E
-client and a stubbed ``ensure_sensors`` (so no live API and no database are touched). We
-focus on the graceful handling of neighbours that publish no wind & solar forecast (e.g.
-NO_2 / DK_1): residual load must fall back to the plain load forecast instead of crashing.
+These exercise the orchestration in ``prices/regressors_import.py`` with a *mocked* ENTSO-E
+client and stubbed DB helpers (so no live API and no database are touched). Two things are
+covered:
+
+- graceful handling of neighbours that publish no wind & solar forecast (e.g. NO_2 / DK_1):
+  residual load must fall back to the plain load forecast instead of crashing;
+- that each country's sensors are ensured/saved under *its own* timezone and with plain
+  (unsuffixed) sensor names, and that neighbours come from ENTSO-E's own NEIGHBOURS mapping.
 
 ``flexmeasures`` must be importable for these (the package __init__ pulls it in); if it is
 not installed, the whole module is skipped.
@@ -15,7 +19,7 @@ import pytest
 
 pytest.importorskip("flexmeasures")
 
-from flexmeasures_entsoe.prices import day_ahead  # noqa: E402
+from flexmeasures_entsoe.prices import regressors_import  # noqa: E402
 
 TZ = "Europe/Amsterdam"
 FROM_TIME = pd.Timestamp("2025-06-02 00:00", tz=TZ)
@@ -53,6 +57,7 @@ class FakeClient:
     """Configurable fake ENTSO-E client.
 
     wind_solar_mode: 'ok' | 'raise' | 'empty' | 'partial'
+    load_mode: 'ok' | 'raise' | 'empty'
     """
 
     def __init__(self, wind_solar_mode="ok", load_mode="ok"):
@@ -79,14 +84,9 @@ class FakeClient:
         )
 
 
-@pytest.fixture
-def stub_ensure_sensors(monkeypatch):
-    """Return sensors named exactly as requested (suffixed), without touching the DB."""
-
-    def _fake_ensure(specs, country_code, timezone):
-        return {spec[0]: FakeSensor(spec[0]) for spec in specs}
-
-    monkeypatch.setattr(day_ahead, "ensure_sensors", _fake_ensure)
+# ---------------------------------------------------------------------------
+# _collect_country_regressors: graceful missing-data handling
+# ---------------------------------------------------------------------------
 
 
 def _collect(client, **kwargs):
@@ -94,76 +94,88 @@ def _collect(client, **kwargs):
     defaults = dict(
         client=client,
         log=log,
-        data_country_code="NO_2",
-        sensor_timezone=TZ,
+        country_code="NO_2",
         from_time=FROM_TIME,
         until_time=UNTIL_TIME,
         include_load_forecast=True,
         include_wind_solar_forecast=True,
         include_residual_load=True,
         include_outages=False,
-        suffix=" (NO_2)",
         strict=False,
     )
     defaults.update(kwargs)
-    triples = day_ahead._collect_country_regressors(**defaults)
-    return triples, log
+    results = regressors_import._collect_country_regressors(**defaults)
+    return results, log
 
 
-def _by_sensor_name(triples):
-    return {sensor.name: series for sensor, series, _ in triples}
+def _by_name(results):
+    """Map base sensor name -> series (results are (spec, override, series, is_entsoe))."""
+    return {spec[0]: series for spec, _override, series, _is_entsoe in results}
 
 
 @pytest.mark.parametrize("wind_solar_mode", ["raise", "empty"])
-def test_neighbour_without_wind_solar_falls_back_to_load(
-    stub_ensure_sensors, wind_solar_mode
-):
+def test_neighbour_without_wind_solar_falls_back_to_load(wind_solar_mode):
     """A neighbour that publishes no wind & solar must not crash; residual == load."""
     client = FakeClient(wind_solar_mode=wind_solar_mode)
-    triples, log = _collect(client)
+    results, log = _collect(client)
 
-    saved = _by_sensor_name(triples)
-    # Load forecast is still saved.
-    assert "Day-ahead load forecast (NO_2)" in saved
-    # No wind/solar sensors were produced.
+    saved = _by_name(results)
+    assert "Day-ahead load forecast" in saved
     assert not any(name.startswith(("Solar", "Wind")) for name in saved)
     # Residual load exists and equals the load forecast (green fell back to zero).
-    assert "Residual load (NO_2)" in saved
-    residual = saved["Residual load (NO_2)"]
-    assert residual.to_numpy() == pytest.approx([12000.0] * len(HOURLY))
-    # A warning was logged about the missing wind & solar data.
+    assert "Residual load" in saved
+    assert saved["Residual load"].to_numpy() == pytest.approx([12000.0] * len(HOURLY))
     assert any("wind & solar" in w for w in log.warnings)
 
 
-def test_neighbour_partial_wind_solar_used_for_residual(stub_ensure_sensors):
+def test_neighbour_partial_wind_solar_used_for_residual():
     """If only Solar is published, residual subtracts just Solar (missing wind = 0)."""
     client = FakeClient(wind_solar_mode="partial")
-    triples, _ = _collect(client)
+    results, _ = _collect(client)
 
-    saved = _by_sensor_name(triples)
-    # Only the Solar sensor is produced (wind columns absent).
-    assert "Solar (NO_2)" in saved
-    assert "Wind Onshore (NO_2)" not in saved
-    assert "Wind Offshore (NO_2)" not in saved
+    saved = _by_name(results)
+    assert "Solar" in saved
+    assert "Wind Onshore" not in saved
+    assert "Wind Offshore" not in saved
     # Residual = 12000 - 2000 = 10000.
-    residual = saved["Residual load (NO_2)"]
-    assert residual.to_numpy() == pytest.approx([10000.0] * len(HOURLY))
+    assert saved["Residual load"].to_numpy() == pytest.approx([10000.0] * len(HOURLY))
 
 
-def test_neighbour_missing_load_skips_residual(stub_ensure_sensors):
+def test_neighbour_missing_load_skips_residual():
     """Without a load forecast we cannot derive residual load, but must not crash."""
     client = FakeClient(load_mode="raise", wind_solar_mode="ok")
-    triples, log = _collect(client)
+    results, log = _collect(client)
 
-    saved = _by_sensor_name(triples)
-    assert "Day-ahead load forecast (NO_2)" not in saved
-    assert "Residual load (NO_2)" not in saved
-    # Wind & solar are still saved (they don't depend on load).
-    assert "Solar (NO_2)" in saved
+    saved = _by_name(results)
+    assert "Day-ahead load forecast" not in saved
+    assert "Residual load" not in saved
+    assert "Solar" in saved  # wind & solar don't depend on load
     assert any("cannot derive residual load" in w for w in log.warnings)
 
 
-def test_strict_mode_aborts_on_empty_price_country_data(stub_ensure_sensors):
+def test_full_neighbour_data_produces_all_specs():
+    """With complete data a neighbour yields load, three green, and residual specs."""
+    client = FakeClient(wind_solar_mode="ok")
+    results, _ = _collect(client)
+
+    saved = _by_name(results)
+    assert set(saved) == {
+        "Day-ahead load forecast",
+        "Solar",
+        "Wind Onshore",
+        "Wind Offshore",
+        "Residual load",
+    }
+    # Residual = 12000 - 2000 - 1000 - 500 = 8500.
+    assert saved["Residual load"].to_numpy() == pytest.approx([8500.0] * len(HOURLY))
+    # Residual load is flagged as derived (not straight-from-ENTSO-E) data.
+    residual_is_entsoe = [
+        is_entsoe for spec, _o, _s, is_entsoe in results if spec[0] == "Residual load"
+    ][0]
+    assert residual_is_entsoe is False
+
+
+def test_strict_mode_aborts_on_empty_price_country_data():
     """For the price country (strict), empty ENTSO-E data aborts, as the price import does."""
     import click
 
@@ -171,27 +183,66 @@ def test_strict_mode_aborts_on_empty_price_country_data(stub_ensure_sensors):
     with pytest.raises(click.Abort):
         _collect(
             client,
-            data_country_code="NL",
-            suffix="",
+            country_code="NL",
             strict=True,
             include_wind_solar_forecast=False,
             include_residual_load=False,
         )
 
 
-def test_full_neighbour_data_produces_all_sensors(stub_ensure_sensors):
-    """With complete data a neighbour yields load, three green, and residual sensors."""
-    client = FakeClient(wind_solar_mode="ok")
-    triples, _ = _collect(client)
+# ---------------------------------------------------------------------------
+# collect_and_save_regressors: per-country timezone, base names, neighbours
+# ---------------------------------------------------------------------------
 
-    names = set(_by_sensor_name(triples))
-    assert names == {
-        "Day-ahead load forecast (NO_2)",
-        "Solar (NO_2)",
-        "Wind Onshore (NO_2)",
-        "Wind Offshore (NO_2)",
-        "Residual load (NO_2)",
-    }
-    # Residual = 12000 - 2000 - 1000 - 500 = 8500.
-    residual = _by_sensor_name(triples)["Residual load (NO_2)"]
-    assert residual.to_numpy() == pytest.approx([8500.0] * len(HOURLY))
+
+def test_collect_and_save_uses_each_country_own_timezone_and_base_names(monkeypatch):
+    ensure_calls = []
+    save_calls = []
+
+    def fake_ensure(specs, country_code, timezone):
+        ensure_calls.append((country_code, timezone, [s[0] for s in specs]))
+        return {s[0]: FakeSensor(s[0]) for s in specs}
+
+    def fake_save(series, sensor, source, timezone, now):
+        save_calls.append((sensor.name, timezone, source))
+
+    monkeypatch.setattr(regressors_import, "ensure_sensors", fake_ensure)
+    monkeypatch.setattr(regressors_import, "save_entsoe_series", fake_save)
+    monkeypatch.setattr(regressors_import, "resample_if_needed", lambda s, sensor: s)
+    monkeypatch.setattr(
+        regressors_import, "ensure_data_source_for_derived_data", lambda: "DERIVED"
+    )
+
+    regressors_import.collect_and_save_regressors(
+        client=FakeClient(wind_solar_mode="ok"),
+        log=FakeLog(),
+        dryrun=False,
+        country_code="NL",
+        country_timezone="Europe/Amsterdam",
+        from_time=FROM_TIME,
+        until_time=UNTIL_TIME,
+        now=None,
+        entsoe_data_source="ENTSOE",
+        include_load_forecast=False,
+        include_wind_solar_forecast=False,
+        include_residual_load=True,
+        include_outages=False,
+        include_neighbours=True,
+    )
+
+    tz_by_country = {country: tz for country, tz, _names in ensure_calls}
+    # Price country and neighbours (from entsoe.mappings.NEIGHBOURS) each ensured.
+    assert tz_by_country["NL"] == "Europe/Amsterdam"
+    assert "BE" in tz_by_country  # a neighbour from the ENTSO-E mapping
+    # Each sensor carries its OWN country's timezone.
+    assert tz_by_country["GB"] == "Europe/London"
+    assert tz_by_country["NO_2"] == "Europe/Oslo"
+    assert tz_by_country["DK_1"] == "Europe/Copenhagen"
+
+    # Sensor names are plain base names (identity comes from the asset, not a suffix).
+    all_names = [name for _c, _tz, names in ensure_calls for name in names]
+    assert "Residual load" in all_names
+    assert all("(" not in name for name in all_names)
+
+    # Residual load is saved from the derived source, with the country's own timezone.
+    assert ("Residual load", "Europe/London", "DERIVED") in save_calls

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -22,6 +22,7 @@ _REGRESSORS_PATH = os.path.join(
     _HERE, "..", "flexmeasures_entsoe", "prices", "regressors.py"
 )
 _spec = importlib.util.spec_from_file_location("_entsoe_regressors", _REGRESSORS_PATH)
+assert _spec is not None and _spec.loader is not None
 regressors = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(regressors)
 

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -1,0 +1,269 @@
+"""
+Unit tests for the novel price-regressor helpers:
+
+- the residual-load derivation, and
+- the generation-outage aggregation with its day-ahead knowledge horizon.
+
+These test only the pure functions, so they need neither a FlexMeasures app nor a
+database. To avoid importing the whole ``flexmeasures_entsoe`` package (whose __init__
+pulls in FlexMeasures), we load ``regressors.py`` directly from its file path.
+"""
+
+import importlib.util
+import os
+
+import pandas as pd
+import pytest
+
+
+# Load flexmeasures_entsoe/prices/regressors.py in isolation.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REGRESSORS_PATH = os.path.join(
+    _HERE, "..", "flexmeasures_entsoe", "prices", "regressors.py"
+)
+_spec = importlib.util.spec_from_file_location("_entsoe_regressors", _REGRESSORS_PATH)
+regressors = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(regressors)
+
+TZ = "Europe/Amsterdam"
+
+
+def _ts(value: str) -> pd.Timestamp:
+    return pd.Timestamp(value, tz=TZ)
+
+
+# ---------------------------------------------------------------------------
+# Residual load
+# ---------------------------------------------------------------------------
+
+
+def test_compute_residual_load_subtracts_all_green_components():
+    index = pd.date_range("2025-06-01", periods=3, freq="1h", tz=TZ)
+    load = pd.Series([10000.0, 11000.0, 12000.0], index=index)
+    solar = pd.Series([2000.0, 3000.0, 500.0], index=index)
+    wind_offshore = pd.Series([1000.0, 1000.0, 1000.0], index=index)
+    wind_onshore = pd.Series([500.0, 700.0, 900.0], index=index)
+
+    residual = regressors.compute_residual_load(
+        load, solar, wind_offshore, wind_onshore
+    )
+
+    expected = pd.Series([6500.0, 6300.0, 9600.0], index=index)
+    pd.testing.assert_series_equal(
+        residual, expected.rename("Residual load"), check_freq=False
+    )
+
+
+def test_compute_residual_load_treats_missing_green_as_zero():
+    """A green component that is absent (NaN after alignment) should not raise the residual."""
+    index = pd.date_range("2025-06-01", periods=2, freq="1h", tz=TZ)
+    load = pd.Series([10000.0, 11000.0], index=index)
+    solar = pd.Series([2000.0, 3000.0], index=index)
+    # Wind offshore only reported for the first hour.
+    wind_offshore = pd.Series([1000.0], index=index[:1])
+    wind_onshore = pd.Series([500.0, 700.0], index=index)
+
+    residual = regressors.compute_residual_load(
+        load, solar, wind_offshore, wind_onshore
+    )
+
+    # Hour 0: 10000 - 2000 - 1000 - 500 = 6500
+    # Hour 1: 11000 - 3000 -    0 - 700 = 7300 (missing offshore treated as 0)
+    assert residual.iloc[0] == pytest.approx(6500.0)
+    assert residual.iloc[1] == pytest.approx(7300.0)
+
+
+# ---------------------------------------------------------------------------
+# Outage aggregation with knowledge horizon
+# ---------------------------------------------------------------------------
+
+
+def _outages_df(rows) -> pd.DataFrame:
+    """Build an outages DataFrame shaped like entsoe-py's, indexed by created_doc_time."""
+    df = pd.DataFrame(
+        rows,
+        columns=[
+            "created_doc_time",
+            "nominal_power",
+            "start",
+            "end",
+            "avail_qty",
+        ],
+    )
+    return df.set_index("created_doc_time")
+
+
+def test_outage_unavailable_mw_is_nominal_minus_available():
+    # Delivery day is 2025-06-02; published the day before -> counts.
+    outages = _outages_df(
+        [
+            (
+                _ts("2025-06-01 09:00"),  # created_doc_time (before delivery day)
+                500.0,  # nominal_power
+                _ts("2025-06-02 00:00"),  # start
+                _ts("2025-06-03 00:00"),  # end (whole delivery day)
+                200.0,  # avail_qty -> unavailable = 300 MW
+            )
+        ]
+    )
+    from_time = _ts("2025-06-02 00:00")
+    until_time = _ts("2025-06-03 00:00")
+
+    result = regressors.aggregate_outages_to_hourly_unavailable_mw(
+        outages, from_time, until_time
+    )
+
+    assert len(result) == 24
+    assert (result == 300.0).all()
+
+
+def test_outage_published_on_delivery_day_is_excluded_no_lookahead_leak():
+    """An outage published on/after the delivery day must not be counted (look-ahead leak)."""
+    delivery_day_outage = _outages_df(
+        [
+            (
+                _ts("2025-06-02 06:00"),  # published DURING the delivery day
+                500.0,
+                _ts("2025-06-02 00:00"),
+                _ts("2025-06-03 00:00"),
+                0.0,  # fully unavailable
+            )
+        ]
+    )
+    from_time = _ts("2025-06-02 00:00")
+    until_time = _ts("2025-06-03 00:00")
+
+    result = regressors.aggregate_outages_to_hourly_unavailable_mw(
+        delivery_day_outage, from_time, until_time
+    )
+
+    # Nothing may be counted: it was not known before the delivery day.
+    assert (result == 0.0).all()
+
+
+def test_outage_knowledge_horizon_is_per_delivery_day_over_multiday_range():
+    """Same outage doc counts for a later delivery day but not for one before it was published."""
+    outages = _outages_df(
+        [
+            (
+                _ts("2025-06-02 10:00"),  # published on June 2
+                400.0,
+                _ts("2025-06-02 00:00"),
+                _ts("2025-06-04 00:00"),  # spans June 2 and June 3
+                0.0,  # fully unavailable -> 400 MW
+            )
+        ]
+    )
+    from_time = _ts("2025-06-02 00:00")
+    until_time = _ts("2025-06-04 00:00")  # two delivery days
+
+    result = regressors.aggregate_outages_to_hourly_unavailable_mw(
+        outages, from_time, until_time
+    )
+
+    june_2 = result[result.index.normalize() == _ts("2025-06-02")]
+    june_3 = result[result.index.normalize() == _ts("2025-06-03")]
+
+    # June 2 delivery: outage published same day -> not known before -> excluded.
+    assert (june_2 == 0.0).all()
+    # June 3 delivery: outage was published on June 2 (before that delivery day) -> counted.
+    assert (june_3 == 400.0).all()
+
+
+def test_outage_only_counts_overlapping_hours():
+    outages = _outages_df(
+        [
+            (
+                _ts("2025-06-01 09:00"),
+                600.0,
+                _ts("2025-06-02 03:00"),  # outage from 03:00 ...
+                _ts("2025-06-02 06:00"),  # ... until 06:00 (exclusive)
+                100.0,  # unavailable = 500 MW
+            )
+        ]
+    )
+    from_time = _ts("2025-06-02 00:00")
+    until_time = _ts("2025-06-03 00:00")
+
+    result = regressors.aggregate_outages_to_hourly_unavailable_mw(
+        outages, from_time, until_time
+    )
+
+    # Hours 03:00, 04:00, 05:00 overlap; others do not.
+    overlapping = [
+        _ts("2025-06-02 03:00"),
+        _ts("2025-06-02 04:00"),
+        _ts("2025-06-02 05:00"),
+    ]
+    for hour in result.index:
+        if hour in overlapping:
+            assert result[hour] == pytest.approx(500.0)
+        else:
+            assert result[hour] == pytest.approx(0.0)
+
+
+def test_outage_multiple_overlapping_outages_are_summed():
+    outages = _outages_df(
+        [
+            (
+                _ts("2025-06-01 09:00"),
+                500.0,
+                _ts("2025-06-02 00:00"),
+                _ts("2025-06-03 00:00"),
+                0.0,  # 500 MW all day
+            ),
+            (
+                _ts("2025-06-01 10:00"),
+                300.0,
+                _ts("2025-06-02 10:00"),
+                _ts("2025-06-02 12:00"),
+                0.0,  # extra 300 MW during 10:00-12:00
+            ),
+        ]
+    )
+    from_time = _ts("2025-06-02 00:00")
+    until_time = _ts("2025-06-03 00:00")
+
+    result = regressors.aggregate_outages_to_hourly_unavailable_mw(
+        outages, from_time, until_time
+    )
+
+    assert result[_ts("2025-06-02 09:00")] == pytest.approx(500.0)
+    assert result[_ts("2025-06-02 10:00")] == pytest.approx(800.0)
+    assert result[_ts("2025-06-02 11:00")] == pytest.approx(800.0)
+    assert result[_ts("2025-06-02 12:00")] == pytest.approx(500.0)
+
+
+def test_outage_empty_frame_returns_zero_series():
+    empty = _outages_df([])
+    from_time = _ts("2025-06-02 00:00")
+    until_time = _ts("2025-06-03 00:00")
+
+    result = regressors.aggregate_outages_to_hourly_unavailable_mw(
+        empty, from_time, until_time
+    )
+
+    assert len(result) == 24
+    assert (result == 0.0).all()
+
+
+def test_outage_ignores_rows_without_nominal_power():
+    outages = _outages_df(
+        [
+            (
+                _ts("2025-06-01 09:00"),
+                float("nan"),  # unknown nominal power -> skipped
+                _ts("2025-06-02 00:00"),
+                _ts("2025-06-03 00:00"),
+                0.0,
+            )
+        ]
+    )
+    from_time = _ts("2025-06-02 00:00")
+    until_time = _ts("2025-06-03 00:00")
+
+    result = regressors.aggregate_outages_to_hourly_unavailable_mw(
+        outages, from_time, until_time
+    )
+
+    assert (result == 0.0).all()

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -73,6 +73,51 @@ def test_compute_residual_load_treats_missing_green_as_zero():
     assert residual.iloc[1] == pytest.approx(7300.0)
 
 
+def test_compute_residual_load_without_any_green_equals_load():
+    """When no wind & solar is published (all green missing), residual load == load."""
+    index = pd.date_range("2025-06-01", periods=3, freq="1h", tz=TZ)
+    load = pd.Series([9000.0, 9500.0, 10000.0], index=index)
+    empty = pd.Series(dtype="float64")
+
+    residual = regressors.compute_residual_load(load, empty, empty, empty)
+
+    pd.testing.assert_series_equal(
+        residual, load.rename("Residual load"), check_freq=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Neighbour mapping and green-column tolerance
+# ---------------------------------------------------------------------------
+
+
+def test_interconnected_neighbours_for_nl():
+    assert regressors.INTERCONNECTED_NEIGHBOURS["NL"] == [
+        "DE_LU",
+        "BE",
+        "GB",
+        "NO_2",
+        "DK_1",
+    ]
+
+
+def test_interconnected_neighbours_unknown_country_defaults_to_empty():
+    # The command uses .get(country, []) so unlisted countries are a no-op, not an error.
+    assert regressors.INTERCONNECTED_NEIGHBOURS.get("XX", []) == []
+
+
+def test_green_column_returns_none_when_forecast_is_none():
+    # Happens for neighbours (e.g. NO_2 / DK_1) that publish no wind & solar forecast.
+    for column in regressors.GREEN_COLUMNS:
+        assert regressors.green_column(None, column) is None
+
+
+def test_green_column_returns_none_when_column_absent():
+    df = pd.DataFrame({"Solar": [1.0, 2.0]})
+    assert regressors.green_column(df, "Wind Offshore") is None
+    assert regressors.green_column(df, "Solar") is not None
+
+
 # ---------------------------------------------------------------------------
 # Outage aggregation with knowledge horizon
 # ---------------------------------------------------------------------------

--- a/tests/test_regressors.py
+++ b/tests/test_regressors.py
@@ -91,19 +91,34 @@ def test_compute_residual_load_without_any_green_equals_load():
 # ---------------------------------------------------------------------------
 
 
-def test_interconnected_neighbours_for_nl():
-    assert regressors.INTERCONNECTED_NEIGHBOURS["NL"] == [
-        "DE_LU",
-        "BE",
-        "GB",
-        "NO_2",
-        "DK_1",
-    ]
+def test_neighbours_for_nl_comes_from_entsoe_mapping():
+    # Sourced from entsoe.mappings.NEIGHBOURS, so it covers the NW-European interconnectors.
+    neighbours = regressors.neighbours_for("NL")
+    for expected in ("BE", "DE_LU", "GB", "NO_2", "DK_1"):
+        assert expected in neighbours
 
 
-def test_interconnected_neighbours_unknown_country_defaults_to_empty():
-    # The command uses .get(country, []) so unlisted countries are a no-op, not an error.
-    assert regressors.INTERCONNECTED_NEIGHBOURS.get("XX", []) == []
+def test_neighbours_for_unknown_country_is_empty():
+    # Unlisted countries make --include-neighbours a no-op, not an error.
+    assert regressors.neighbours_for("XX") == []
+
+
+def test_neighbours_for_returns_a_fresh_list():
+    # Callers must not be able to mutate the library's mapping.
+    first = regressors.neighbours_for("NL")
+    first.append("ZZ")
+    assert "ZZ" not in regressors.neighbours_for("NL")
+
+
+def test_timezone_for_known_zones():
+    assert regressors.timezone_for("NL") == "Europe/Amsterdam"
+    assert regressors.timezone_for("GB") == "Europe/London"
+    assert regressors.timezone_for("NO_2") == "Europe/Oslo"
+    assert regressors.timezone_for("DK_1") == "Europe/Copenhagen"
+
+
+def test_timezone_for_unknown_zone_is_none():
+    assert regressors.timezone_for("not-a-zone") is None
 
 
 def test_green_column_returns_none_when_forecast_is_none():


### PR DESCRIPTION
## Why

Research on the Dutch (NL) day-ahead market established that ENTSO-E day-ahead **fundamentals** dramatically improve day-ahead **price** forecasting, especially for hard cases (public holidays and the solar-driven midday price collapse):

- **Residual load** (= day-ahead load forecast − day-ahead wind forecast − day-ahead solar forecast) is the single best regressor. On real ENTSO-E forecasts it cut holiday forecast error substantially and even beat using actuals — because the day-ahead *price* is formed against these very forecasts. It flattens the spurious holiday-morning price peak and captures the midday collapse.
- **Generation outages** (day-ahead-known unavailable capacity) are a weaker but physically relevant regressor for scarcity.
- **Neighbouring countries** matter too: a €500+/MWh NL scarcity spike is usually a *regional* NW-European event — Germany, Belgium, Great Britain and the Nordics are tight at the same time, so imports into NL dry up. Neighbours' day-ahead residual-load forecasts measurably improve NL spike and evening-peak forecasts.

So FlexMeasures needs these series saved as sensors for the forecaster to use.

## What was added

`import-day-ahead-prices` can now *also* import (configurably) these regressor series, each into its own sensor (MW). Independent boolean flags (matching the repo's `--x/--no-x` style), all default **off**:

| Flag | Sensor(s) | Unit | Source |
| --- | --- | --- | --- |
| `--include-load-forecast` | `Day-ahead load forecast` | MW | ENTSO-E |
| `--include-wind-solar-forecast` | `Solar`, `Wind Onshore`, `Wind Offshore` (shared with the generation import) | MW | ENTSO-E |
| `--include-residual-load` | `Residual load` | MW | derived (`ENTSOE_DERIVED_DATA_SOURCE`) |
| `--include-outages` | `Generation outages` | MW | ENTSO-E |
| `--include-neighbours` | the selected regressors above (except outages), for each neighbour, on the neighbour's own transmission-zone asset | MW | ENTSO-E / derived |
| `--include-all` | shorthand: turns on every regressor **and** `--include-neighbours` | MW | ENTSO-E / derived |

`--include-residual-load` implies fetching both the load and wind & solar forecasts (needed to derive it), but only *saves* those if their own flag is set. `--include-all` composes with the individual flags. Each single-sensor regressor can be pointed at a specific sensor with `--load-forecast-sensor` / `--residual-load-sensor` / `--outages-sensor`.

### Neighbour-country regressors

- **Neighbour set from the library, not hardcoded:** taken directly from `entsoe.mappings.NEIGHBOURS` (a maintained upstream area→neighbours dict), so it covers every country and tracks interconnection changes as `entsoe-py` is updated. For NL: `BE, DE_LU, DE_AT_LU, GB, NO_2, DK_1`. The codes are already accepted by the query functions via `lookup_area`; a zone with no day-ahead data (e.g. the deprecated `DE_AT_LU`) is simply skipped by the lenient fetch.
- **Identity by asset, not name suffix:** each neighbour's series are saved to *plainly-named* sensors (`Residual load`, `Day-ahead load forecast`, …) on **that neighbour's own transmission-zone asset**. So NL's `Residual load` and DE_LU's `Residual load` are distinct sensors on distinct assets.
- **Own timezone per country:** each country's sensors carry their own timezone via `entsoe-py`'s `Area.tz` (NL/DE/BE → `Europe/…`, GB → `Europe/London`, NO_2 → `Europe/Oslo`, DK_1 → `Europe/Copenhagen`).
- **Graceful missing data:** neighbour queries are lenient — if a neighbour publishes no data for a series (e.g. NO_2 / DK_1 wind & solar, whether the query raises or returns empty), it's skipped with a warning and **residual load falls back to the plain load forecast**. Sensors are ensured **lazily**, only for series that actually have data, so dead zones create no empty assets/sensors. The price country stays strict and aborts on empty data.

### Knowledge-horizon correctness for outages

For each target hour we sum the unavailable capacity (`nominal_power − avail_qty`) of every outage overlapping that hour, but **only if the outage was published (`created_doc_time`) before that hour's delivery day** (local midnight). Day-ahead prices are set with only the information known before the delivery day, so counting a later-announced outage would leak look-ahead information. Checked per target hour, so multi-day ranges aggregate correctly.

### Structure & housekeeping

- Orchestration moved out of `day_ahead.py` into a dedicated `prices/regressors_import.py`; `day_ahead.py` stays thin (CLI wiring + price import + one call). `prices/regressors.py` holds only pure, dependency-light helpers (residual-load derivation, outage aggregation, `neighbours_for`, `timezone_for`), unit-testable without an app/DB.
- Package version bumped **0.9 → 0.10**.
- Merged latest `origin/main` (resolved conflicts against the new data-source/account logic, `parse_from_and_to_dates`, `abort_if_data_incomplete`, and the `ensure_sensors` type hint). Branch is mergeable.
- Drive-by (from the original commit): removed a stray committed `breakpoint()` in `utils.resample_if_needed` that halted every resampling import path.

## How to use

```bash
# Everything (all regressors + neighbours):
flexmeasures entsoe import-day-ahead-prices --include-all

# Just the strongest regressor, for NL and its neighbours:
flexmeasures entsoe import-day-ahead-prices --include-residual-load --include-neighbours
```

## Tests

Pure helpers in `prices/regressors.py` are unit-tested in `tests/test_regressors.py` (no app/DB/API — loaded by path): residual-load derivation (incl. all-green-missing fallback == load), outage aggregation with the knowledge-horizon exclusion (verified across a multi-day range), and `neighbours_for` / `timezone_for`.

`tests/test_neighbours.py` exercises `regressors_import` with a **mocked** ENTSO-E client and stubbed DB helpers (`pytest.importorskip("flexmeasures")`): missing wind & solar (raise *or* empty) → residual falls back to load; partial green; missing load → residual skipped; strict-abort for the price country; and an orchestration test asserting each country (price country + neighbours from `NEIGHBOURS`) is ensured/saved under its **own timezone** with **plain base names** (no suffix), residual from the derived source.

Locally: 29 passed, 2 skipped (FM-version-gated), plus `black` (repo-pinned 22.10.0), `flake8` and `mypy` clean.

## Notes for the maintainer / decisions

- **Neighbour data volume:** using `entsoe.mappings.NEIGHBOURS` means a few extra queries for zones with no current day-ahead data (e.g. `DE_AT_LU`); these are skipped leniently and create no sensors. Filtering deprecated zones would require a hand-maintained list, which this deliberately avoids.
- No CHANGELOG file exists in the repo; documented the feature in the README instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6t3NeRRhFtLc4KvCCxFBt